### PR TITLE
Add shellcheck to the CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Set Golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
 
+      - name: Set Shellcheck
+        run: sudo apt-get -qq update && sudo apt-get install -y shellcheck && shellcheck install-binary.sh
+
       - name: Build
         run: make build
 


### PR DESCRIPTION
Based on the steps executed in the bitnami/minideb CI, see https://github.com/bitnami/minideb/blob/cf60555a1a6a7f3b5aca496e156dade0e16add8b/.github/workflows/main.yml#L22