### PR TITLE
Preserve manifest digest by saving images as OCI layouts

### DIFF
--- a/cmd/dt/pull_test.go
+++ b/cmd/dt/pull_test.go
@@ -51,8 +51,8 @@ func (suite *CmdSuite) TestPullCommand() {
 		suite.Require().DirExists(imagesDir)
 		for _, imgData := range images {
 			for _, digestData := range imgData.Digests {
-				imgFile := filepath.Join(imagesDir, fmt.Sprintf("%s.tar", digestData.Digest.Encoded()))
-				suite.Assert().FileExists(imgFile)
+				imgDir := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", digestData.Digest.Encoded()))
+				suite.Assert().DirExists(imgDir)
 			}
 		}
 	}

--- a/cmd/dt/push_test.go
+++ b/cmd/dt/push_test.go
@@ -87,7 +87,6 @@ func (suite *CmdSuite) TestPushCommand() {
 		chartName := "test"
 
 		scenarioDir := fmt.Sprintf("../../testdata/scenarios/%s", scenarioName)
-		imageName := "test:mytag"
 
 		imageData := tu.ImageData{Name: "test", Image: "test:mytag"}
 		architectures := []string{
@@ -119,8 +118,8 @@ func (suite *CmdSuite) TestPushCommand() {
 			if err != nil {
 				t.Fatal(err)
 			}
-			imgFile := filepath.Join(imagesDir, fmt.Sprintf("%s.tar", d.Hex))
-			if err := crane.Save(img, imageName, imgFile); err != nil {
+			imgDir := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", d.Hex))
+			if err := crane.SaveOCI(img, imgDir); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/cmd/dt/unwrap_test.go
+++ b/cmd/dt/unwrap_test.go
@@ -115,10 +115,10 @@ func writeSampleImages(imageName string, imageTag string, dir string) ([]tu.Imag
 			return nil, fmt.Errorf("failed to get image digest: %w", err)
 		}
 
-		imgFileName := filepath.Join(dir, fmt.Sprintf("%s.tar", d.Hex))
+		imgDir := filepath.Join(dir, fmt.Sprintf("%s.layout", d.Hex))
 
-		if err := crane.Save(img, fullImageName, imgFileName); err != nil {
-			return nil, fmt.Errorf("failed to save image %q to %q: %w", fullImageName, imgFileName, err)
+		if err := crane.SaveOCI(img, imgDir); err != nil {
+			return nil, fmt.Errorf("failed to save image %q to %q: %w", fullImageName, imgDir, err)
 		}
 
 	}

--- a/cmd/dt/wrap_test.go
+++ b/cmd/dt/wrap_test.go
@@ -121,8 +121,8 @@ func testChartWrap(t *testing.T, sb *tu.Sandbox, inputChart string, expectedLock
 	require.DirExists(t, imagesDir)
 	for _, imgData := range cfg.Images {
 		for _, digestData := range imgData.Digests {
-			imgFile := filepath.Join(imagesDir, fmt.Sprintf("%s.tar", digestData.Digest.Encoded()))
-			assert.FileExists(t, imgFile)
+			imgDir := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", digestData.Digest.Encoded()))
+			assert.DirExists(t, imgDir)
 		}
 	}
 	wrappedChartDir := filepath.Join(tmpDir, "chart")

--- a/pkg/chartutils/images.go
+++ b/pkg/chartutils/images.go
@@ -194,14 +194,14 @@ func loadImage(path string) (v1.Image, error) {
 	if !stat.IsDir() {
 		img, err := crane.Load(path)
 		if err != nil {
-			return nil, fmt.Errorf("loading %s as tarball: %w", path, err)
+			return nil, fmt.Errorf("could not load %q as tarball: %w", path, err)
 		}
 		return img, nil
 	}
 
 	l, err := layout.ImageIndexFromPath(path)
 	if err != nil {
-		return nil, fmt.Errorf("loading %s as OCI layout: %w", path, err)
+		return nil, fmt.Errorf("could load %q as OCI layout: %w", path, err)
 	}
 	m, err := l.IndexManifest()
 	if err != nil {
@@ -222,7 +222,7 @@ func buildImageIndex(image *imagelock.ChartImage, imagesDir string) (v1.ImageInd
 
 	base := mutate.IndexMediaType(empty.Index, types.DockerManifestList)
 	for _, dgstData := range image.Digests {
-		imgDir := getImageLayourDir(imagesDir, dgstData)
+		imgDir := getImageLayoutDir(imagesDir, dgstData)
 
 		img, err := loadImage(imgDir)
 		if err != nil {
@@ -264,12 +264,12 @@ func pushImage(imgData *imagelock.ChartImage, imagesDir string, o crane.Options)
 	return nil
 }
 
-func getImageLayourDir(imagesDir string, dgst imagelock.DigestInfo) string {
+func getImageLayoutDir(imagesDir string, dgst imagelock.DigestInfo) string {
 	return filepath.Join(imagesDir, fmt.Sprintf("%s.layout", dgst.Digest.Encoded()))
 }
 
 func pullImage(image string, digest imagelock.DigestInfo, imagesDir string, o crane.Options) (string, error) {
-	imgDir := getImageLayourDir(imagesDir, digest)
+	imgDir := getImageLayoutDir(imagesDir, digest)
 
 	src := fmt.Sprintf("%s@%s", image, digest.Digest)
 	ref, err := name.ParseReference(src, o.Name...)

--- a/pkg/chartutils/images_test.go
+++ b/pkg/chartutils/images_test.go
@@ -61,8 +61,8 @@ func (suite *ChartUtilsTestSuite) TestPullImages() {
 
 		for _, imgData := range images {
 			for _, digestData := range imgData.Digests {
-				imgFile := filepath.Join(imagesDir, fmt.Sprintf("%s.tar", digestData.Digest.Encoded()))
-				suite.Assert().FileExists(imgFile)
+				imgDir := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", digestData.Digest.Encoded()))
+				suite.Assert().DirExists(imgDir)
 			}
 		}
 	})
@@ -90,7 +90,6 @@ func (suite *ChartUtilsTestSuite) TestPushImages() {
 		chartName := "test"
 
 		scenarioDir := fmt.Sprintf("../../testdata/scenarios/%s", scenarioName)
-		imageName := "test:mytag"
 
 		imageData := tu.ImageData{Name: "test", Image: "test:mytag"}
 		architectures := []string{
@@ -122,8 +121,8 @@ func (suite *ChartUtilsTestSuite) TestPushImages() {
 			if err != nil {
 				t.Fatal(err)
 			}
-			imgFile := filepath.Join(imagesDir, fmt.Sprintf("%s.tar", d.Hex))
-			if err := crane.Save(img, imageName, imgFile); err != nil {
+			imgFile := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", d.Hex))
+			if err := crane.SaveOCI(img, imgFile); err != nil {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
This should fix #23 