### PR TITLE
Show a warning when there are no images to annotate

### DIFF
--- a/cmd/dt/annotate.go
+++ b/cmd/dt/annotate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -30,9 +31,14 @@ Use it cautiously. Very often the complete list of images cannot be guessed from
 					chartutils.WithAnnotationsKey(getAnnotationsKey()),
 					chartutils.WithLog(l),
 				)
+
 			})
 
 			if err != nil {
+				if errors.Is(err, chartutils.ErrNoImagesToAnnotate) {
+					l.Warnf("No container images found to be annotated")
+					return nil
+				}
 				return l.Failf("failed to annotate Helm chart %q: %v", chartPath, err)
 			}
 

--- a/cmd/dt/annotate_test.go
+++ b/cmd/dt/annotate_test.go
@@ -89,7 +89,7 @@ func (suite *CmdSuite) TestAnnotateCommand() {
 				map[string]interface{}{"ServerURL": serverURL},
 			))
 
-			dt("charts", "annotate", chartDir).AssertSuccess(t)
+			dt("charts", "annotate", chartDir).AssertSuccessMatch(t, regexp.MustCompile(`No container images found`))
 
 			tu.AssertChartAnnotations(t, chartDir, defaultAnnotationsKey, make([]tu.AnnotationEntry, 0))
 


### PR DESCRIPTION
- When there are images:

```
➜ ./bin/dt charts annotate $CHARTS/wordpress
 🎉  Helm chart annotated successfully
```

- When there are no images:

```
➜ ./bin/dt charts annotate $CHARTS/common
 ⚠️  No container images found to be annotated
```