### PR TITLE
Enforce forward slashes on tgz to properly support Windows

### DIFF
--- a/pkg/utils/tar.go
+++ b/pkg/utils/tar.go
@@ -106,7 +106,7 @@ func TarContext(parentCtx context.Context, sourceDir string, filename string, cf
 			if skip(trimmedPath) {
 				return nil
 			}
-			relPath := filepath.Join(prefix, trimmedPath)
+			relPath := filepath.ToSlash(filepath.Join(prefix, trimmedPath))
 
 			return tarFile(tarWriter, path, relPath, info)
 		}


### PR DESCRIPTION
The Windows tool is generating malformed .tgz when creating wrap bundles because it is adding the paths with backslashes. This patch forces using forward slashes.