### PR TITLE
Automate release preparation

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,39 @@
+name: Prepare release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (i.e. v1.2.3)'
+        required: true
+        type: string
+
+jobs:
+  Prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        with:
+          fetch-depth: 0
+
+      - name: Config Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Fetch Version
+        run: echo PLUGIN_VERSION=$(echo "${{ inputs.tag }}" | tr -d 'v') >> "$GITHUB_ENV"
+
+      - name: Update Version
+        run: |
+          sed -i "s/version: \".*\"/version: \"$PLUGIN_VERSION\"/" plugin.yaml
+          sed -i "s/var Version = \".*\"/var Version = \"$PLUGIN_VERSION\"/" cmd/dt/version.go
+          git checkout -B release/$PLUGIN_VERSION
+          git add plugin.yaml cmd/dt/version.go
+          git commit -m 'Prepare release ${{ inputs.tag }}'
+          git push origin release/$PLUGIN_VERSION
+
+      - name: Create PR
+        run: gh pr create --fill --base main --repo $GITHUB_REPOSITORY
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,17 @@
 name: Release
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (i.e. v1.2.3)'
-        required: true
-        type: string
+  pull_request_target:
+    types:
+      - closed
+    paths:
+      - 'plugin.yaml'
 
 permissions:
   contents: write
 
 jobs:
   Release:
+    if: (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,14 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch Version
-        id: version
-        run: |
-          PLUGIN_VERSION=v$(cat plugin.yaml | grep "version" | cut -d '"' -f 2)
-          echo "::set-output name=PLUGIN_VERSION::$PLUGIN_VERSION"
-
-      - name: Check Version
-        if: ${{ steps.version.outputs.PLUGIN_VERSION != inputs.tag }}
-        run: echo "Plugin version does not match input tag. Please make sure you have prepared the release first." && exit 1
+        run: echo PLUGIN_VERSION=v$(cat plugin.yaml | grep "version" | cut -d '"' -f 2) >> "$GITHUB_ENV"
 
       - name: Set Golang
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
@@ -38,7 +31,7 @@ jobs:
         run: make build
 
       - name: Create tag
-        run: git tag ${{ github.event.inputs.tag }}
+        run: git tag $PLUGIN_VERSION
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0


### PR DESCRIPTION
Remove the need for manual release preparation commits:

- Add a new `Prepare release` workflow that creates a pull request preparing the new release
- Modify the `Release` job to run when:
  - A pull request modifying the `plugins.yaml` is merged, and
  - The pull request head reference matches `release/*`