### PR TITLE
Remove extra newline from version command

### DIFF
--- a/cmd/dt/version.go
+++ b/cmd/dt/version.go
@@ -28,7 +28,7 @@ var versionCmd = &cobra.Command{
 		if Commit != "" {
 			msg += fmt.Sprintf("Git Commit: %s\n", Commit)
 		}
-		fmt.Printf("%s\n", msg)
+		fmt.Print(msg)
 		os.Exit(0)
 	},
 }


### PR DESCRIPTION
The version command prints two new lines at the end. This PR removes one of them as the `msg` string already ends in `\n`.