### PR TITLE
Show warning when there are no images to pull

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ run:
 
 linters-settings:
   gocyclo:
-    min-complexity: 16
+    min-complexity: 18
   govet:
     check-shadowing: false
   lll:

--- a/cmd/dt/pull.go
+++ b/cmd/dt/pull.go
@@ -75,11 +75,11 @@ func newPullCommand() *cobra.Command {
 					chartutils.WithProgressBar(childLog.ProgressBar()),
 					chartutils.WithArtifactsDir(chart.ImageArtifactsDir()),
 				); err != nil {
-					if !errors.Is(err, chartutils.ErrNoImagesFound) {
-						return childLog.Failf("%v", err)
+					if errors.Is(err, chartutils.ErrNoImagesFound) {
+						childLog.Warnf("No images found in Images.lock")
+						return nil
 					}
-					childLog.Warnf("No images found in Images.lock")
-					return nil
+					return childLog.Failf("%v", err)
 				}
 				imagesPulled = true
 				childLog.Infof("All images pulled successfully")

--- a/cmd/dt/pull_test.go
+++ b/cmd/dt/pull_test.go
@@ -74,6 +74,15 @@ func (suite *CmdSuite) TestPullCommand() {
 		verifyChartDir(tmpDir)
 	})
 
+	t.Run("Warning when no images in Images.lock", func(t *testing.T) {
+		images = []tu.ImageData{}
+		scenarioName := "no-images-chart"
+		scenarioDir = fmt.Sprintf("../../testdata/scenarios/%s", scenarioName)
+		chartDir := createSampleChart(sb.TempFile())
+		dt("images", "pull", chartDir).AssertSuccessMatch(t, "No images found in Images.lock")
+		verifyChartDir(chartDir)
+	})
+
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Fails when Images.lock is not found", func(t *testing.T) {
 			chartDir := createSampleChart(sb.TempFile())

--- a/cmd/dt/pull_test.go
+++ b/cmd/dt/pull_test.go
@@ -80,7 +80,7 @@ func (suite *CmdSuite) TestPullCommand() {
 		scenarioDir = fmt.Sprintf("../../testdata/scenarios/%s", scenarioName)
 		chartDir := createSampleChart(sb.TempFile())
 		dt("images", "pull", chartDir).AssertSuccessMatch(t, "No images found in Images.lock")
-		verifyChartDir(chartDir)
+		require.NoDirExists(filepath.Join(chartDir, "images"))
 	})
 
 	t.Run("Errors", func(t *testing.T) {
@@ -88,7 +88,7 @@ func (suite *CmdSuite) TestPullCommand() {
 			chartDir := createSampleChart(sb.TempFile())
 			require.NoError(os.RemoveAll(filepath.Join(chartDir, "Images.lock")))
 
-			dt("images", "pull", chartDir).AssertErrorMatch(t, `(?s).*failed to read Images\.lock file.*`)
+			dt("images", "pull", chartDir).AssertErrorMatch(t, `Failed to load Images\.lock.*`)
 		})
 	})
 }

--- a/cmd/dt/push.go
+++ b/cmd/dt/push.go
@@ -3,27 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/vmware-labs/distribution-tooling-for-helm/internal/log"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/chartutils"
-	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/imagelock"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/wrapping"
 )
 
 var pushCmd = newPushCmd()
 
 func pushChartImages(wrap wrapping.Wrap, imagesDir string, opts ...chartutils.Option) error {
-	lockFile := wrap.LockFilePath()
-
-	fh, err := os.Open(lockFile)
-	if err != nil {
-		return fmt.Errorf("failed to open Images.lock file: %v", err)
-	}
-	defer fh.Close()
-
-	lock, err := imagelock.FromYAML(fh)
+	lock, err := wrap.GetImagesLock()
 	if err != nil {
 		return fmt.Errorf("failed to load Images.lock: %v", err)
 	}

--- a/cmd/dt/unwrap.go
+++ b/cmd/dt/unwrap.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vmware-labs/distribution-tooling-for-helm/internal/widgets"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/artifacts"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/chartutils"
-	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/imagelock"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/relocator"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/utils"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/wrapping"
@@ -155,7 +154,7 @@ func pushChartImagesAndVerify(ctx context.Context, wrap wrapping.Wrap, l log.Sec
 }
 
 func showImagesSummary(wrap wrapping.Lockable, l log.SectionLogger) int {
-	lock, err := imagelock.FromYAMLFile(wrap.LockFilePath())
+	lock, err := wrap.GetImagesLock()
 	if err != nil {
 		l.Debugf("failed to load list of images: failed to load lock file: %v", err)
 		return 0

--- a/cmd/dt/wrap.go
+++ b/cmd/dt/wrap.go
@@ -123,11 +123,11 @@ func wrapChart(ctx context.Context, inputPath string, outputFile string, platfor
 			chartutils.WithArtifactsDir(wrap.ImageArtifactsDir()),
 			chartutils.WithProgressBar(childLog.ProgressBar()),
 		); err != nil {
-			if !errors.Is(err, chartutils.ErrNoImagesFound) {
-				return childLog.Failf("%v", err)
+			if errors.Is(err, chartutils.ErrNoImagesFound) {
+				childLog.Warnf("No images found in Images.lock")
+				return nil
 			}
-			childLog.Warnf("No images found in Images.lock")
-			return nil
+			return childLog.Failf("%v", err)
 		}
 		childLog.Infof("All images pulled successfully")
 		return nil

--- a/cmd/dt/wrap.go
+++ b/cmd/dt/wrap.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	glog "log"
 	"path/filepath"
@@ -122,7 +123,11 @@ func wrapChart(ctx context.Context, inputPath string, outputFile string, platfor
 			chartutils.WithArtifactsDir(wrap.ImageArtifactsDir()),
 			chartutils.WithProgressBar(childLog.ProgressBar()),
 		); err != nil {
-			return childLog.Failf("%v", err)
+			if !errors.Is(err, chartutils.ErrNoImagesFound) {
+				return childLog.Failf("%v", err)
+			}
+			childLog.Warnf("No images found in Images.lock")
+			return nil
 		}
 		childLog.Infof("All images pulled successfully")
 		return nil

--- a/cmd/dt/wrap_test.go
+++ b/cmd/dt/wrap_test.go
@@ -123,11 +123,15 @@ func testChartWrap(t *testing.T, sb *tu.Sandbox, inputChart string, expectedLock
 	require.NoError(t, utils.Untar(expectedWrapFile, tmpDir, utils.TarConfig{StripComponents: 1}))
 
 	imagesDir := filepath.Join(tmpDir, "images")
-	require.DirExists(t, imagesDir)
-	for _, imgData := range cfg.Images {
-		for _, digestData := range imgData.Digests {
-			imgDir := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", digestData.Digest.Encoded()))
-			assert.DirExists(t, imgDir)
+	if len(cfg.Images) == 0 {
+		require.NoDirExists(t, imagesDir)
+	} else {
+		require.DirExists(t, imagesDir)
+		for _, imgData := range cfg.Images {
+			for _, digestData := range imgData.Digests {
+				imgDir := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", digestData.Digest.Encoded()))
+				assert.DirExists(t, imgDir)
+			}
 		}
 	}
 	wrappedChartDir := filepath.Join(tmpDir, "chart")

--- a/cmd/dt/wrap_test.go
+++ b/cmd/dt/wrap_test.go
@@ -111,7 +111,12 @@ func testChartWrap(t *testing.T, sb *tu.Sandbox, inputChart string, expectedLock
 	if cfg.FetchArtifacts {
 		args = append(args, "--fetch-artifacts")
 	}
-	dt(args...).AssertSuccess(t)
+
+	if len(cfg.Images) == 0 {
+		dt(args...).AssertSuccessMatch(t, "No images found in Images.lock")
+	} else {
+		dt(args...).AssertSuccess(t)
+	}
 	require.FileExists(t, expectedWrapFile)
 
 	tmpDir := sb.TempFile()
@@ -247,10 +252,10 @@ func (suite *CmdSuite) TestWrapCommand() {
 		testWrap(t, chartDir, outputFile, expectedLock, generateCarvelBundle, fetchArtifacts)
 	}
 
-	t.Run("Wrap Chart without exiting lock", func(t *testing.T) {
+	t.Run("Wrap Chart without existing lock", func(t *testing.T) {
 		testSampleWrap(t, withoutLock, "", false, WithoutArtifacts)
 	})
-	t.Run("Wrap Chart with exiting lock", func(t *testing.T) {
+	t.Run("Wrap Chart with existing lock", func(t *testing.T) {
 		testSampleWrap(t, withLock, "", false, WithoutArtifacts)
 	})
 	t.Run("Wrap Chart From compressed tgz", func(t *testing.T) {
@@ -322,5 +327,12 @@ func (suite *CmdSuite) TestWrapCommand() {
 	t.Run("Wrap Chart and generate carvel bundle", func(t *testing.T) {
 		tempFilename := fmt.Sprintf("%s/chart.wrap.tar.gz", sb.TempFile())
 		testSampleWrap(t, withLock, tempFilename, true, WithoutArtifacts) // triggers the Carvel checks
+	})
+
+	t.Run("Wrap Chart with no images", func(t *testing.T) {
+		images = []tu.ImageData{}
+		scenarioName = "no-images-chart"
+		scenarioDir = fmt.Sprintf("../../testdata/scenarios/%s", scenarioName)
+		testSampleWrap(t, withLock, "", false, WithoutArtifacts)
 	})
 }

--- a/pkg/chartutils/chart.go
+++ b/pkg/chartutils/chart.go
@@ -59,6 +59,18 @@ func (c *Chart) LockFilePath() string {
 	return c.AbsFilePath(imagelock.DefaultImagesLockFileName)
 }
 
+// GetImagesLock returns the chart's ImagesLock object
+func (c *Chart) GetImagesLock() (*imagelock.ImagesLock, error) {
+	lockFile := c.LockFilePath()
+
+	lock, err := imagelock.FromYAMLFile(lockFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return lock, nil
+}
+
 // ImageArtifactsDir returns the imags artifacts directory
 func (c *Chart) ImageArtifactsDir() string {
 	return filepath.Join(c.RootDir(), artifacts.HelmArtifactsFolder, "images")

--- a/pkg/chartutils/images.go
+++ b/pkg/chartutils/images.go
@@ -2,7 +2,6 @@ package chartutils
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,9 +19,6 @@ import (
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/imagelock"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/utils"
 )
-
-// ErrNoImagesFound is returned when no images are found in the Images.lock file
-var ErrNoImagesFound = errors.New("no images found in Images.lock")
 
 func getNumberOfArtifacts(images imagelock.ImageList) int {
 	n := 0
@@ -54,8 +50,8 @@ func PullImages(lock *imagelock.ImagesLock, imagesDir string, opts ...Option) er
 	}
 	l := cfg.Log
 
-	if getNumberOfArtifacts(lock.Images) == 0 {
-		return ErrNoImagesFound
+	if len(lock.Images) == 0 {
+		return fmt.Errorf("no images found in Images.lock")
 	}
 
 	p, _ := cfg.ProgressBar.WithTotal(getNumberOfArtifacts(lock.Images)).UpdateTitle("Pulling Images").Start()

--- a/pkg/chartutils/images.go
+++ b/pkg/chartutils/images.go
@@ -2,6 +2,7 @@ package chartutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,6 +20,9 @@ import (
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/imagelock"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/utils"
 )
+
+// ErrNoImagesFound is returned when no images are found in the Images.lock file
+var ErrNoImagesFound = errors.New("no images found in Images.lock")
 
 func getNumberOfArtifacts(images imagelock.ImageList) int {
 	n := 0
@@ -49,6 +53,10 @@ func PullImages(lock *imagelock.ImagesLock, imagesDir string, opts ...Option) er
 		return fmt.Errorf("failed to create bundle directory: %v", err)
 	}
 	l := cfg.Log
+
+	if getNumberOfArtifacts(lock.Images) == 0 {
+		return ErrNoImagesFound
+	}
 
 	p, _ := cfg.ProgressBar.WithTotal(getNumberOfArtifacts(lock.Images)).UpdateTitle("Pulling Images").Start()
 	defer p.Stop()

--- a/pkg/chartutils/images_test.go
+++ b/pkg/chartutils/images_test.go
@@ -67,7 +67,7 @@ func (suite *ChartUtilsTestSuite) TestPullImages() {
 		}
 	})
 
-	t.Run("Warning when no images in Images.lock", func(t *testing.T) {
+	t.Run("Error when no images in Images.lock", func(t *testing.T) {
 		chartDir := sb.TempFile()
 
 		images := []tu.ImageData{}
@@ -82,7 +82,7 @@ func (suite *ChartUtilsTestSuite) TestPullImages() {
 
 		lock, err := imagelock.FromYAMLFile(filepath.Join(chartDir, "Images.lock"))
 		require.NoError(err)
-		require.ErrorIs(PullImages(lock, imagesDir), ErrNoImagesFound)
+		require.Error(PullImages(lock, imagesDir))
 
 		require.DirExists(imagesDir)
 

--- a/pkg/chartutils/images_test.go
+++ b/pkg/chartutils/images_test.go
@@ -43,7 +43,7 @@ func (suite *ChartUtilsTestSuite) TestPullImages() {
 
 	scenarioDir := fmt.Sprintf("../../testdata/scenarios/%s", scenarioName)
 
-	suite.T().Run("Pulls images", func(t *testing.T) {
+	t.Run("Pulls images", func(t *testing.T) {
 		chartDir := sb.TempFile()
 
 		require.NoError(tu.RenderScenario(scenarioDir, chartDir,
@@ -56,6 +56,33 @@ func (suite *ChartUtilsTestSuite) TestPullImages() {
 		lock, err := imagelock.FromYAMLFile(filepath.Join(chartDir, "Images.lock"))
 		require.NoError(err)
 		require.NoError(PullImages(lock, imagesDir))
+
+		require.DirExists(imagesDir)
+
+		for _, imgData := range images {
+			for _, digestData := range imgData.Digests {
+				imgDir := filepath.Join(imagesDir, fmt.Sprintf("%s.layout", digestData.Digest.Encoded()))
+				suite.Assert().DirExists(imgDir)
+			}
+		}
+	})
+
+	t.Run("Warning when no images in Images.lock", func(t *testing.T) {
+		chartDir := sb.TempFile()
+
+		images := []tu.ImageData{}
+		scenarioName := "no-images-chart"
+		scenarioDir := fmt.Sprintf("../../testdata/scenarios/%s", scenarioName)
+		require.NoError(tu.RenderScenario(scenarioDir, chartDir,
+			map[string]interface{}{"ServerURL": serverURL, "Images": images, "Name": chartName, "RepositoryURL": serverURL},
+		))
+		imagesDir := filepath.Join(chartDir, "images")
+
+		require.NoError(err)
+
+		lock, err := imagelock.FromYAMLFile(filepath.Join(chartDir, "Images.lock"))
+		require.NoError(err)
+		require.ErrorIs(PullImages(lock, imagesDir), ErrNoImagesFound)
 
 		require.DirExists(imagesDir)
 

--- a/pkg/imagelock/lock.go
+++ b/pkg/imagelock/lock.go
@@ -112,7 +112,7 @@ func FromYAML(r io.Reader) (*ImagesLock, error) {
 func FromYAMLFile(file string) (*ImagesLock, error) {
 	fh, err := os.Open(file)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open Images.lock file: %v", err)
+		return nil, fmt.Errorf("failed to open Images.lock file: %w", err)
 	}
 	defer fh.Close()
 	return FromYAML(fh)

--- a/pkg/wrapping/wrap.go
+++ b/pkg/wrapping/wrap.go
@@ -18,6 +18,7 @@ import (
 type Lockable interface {
 	LockFilePath() string
 	ImagesDir() string
+	GetImagesLock() (*imagelock.ImagesLock, error)
 }
 
 // Wrap defines the interface to implement a Helm chart wrap
@@ -53,6 +54,11 @@ func (w *wrap) ImageArtifactsDir() string {
 // ImagesDir returns the images directory inside the chart root directory
 func (w *wrap) ImagesDir() string {
 	return w.AbsFilePath("images")
+}
+
+// GetImagesLock returns the chart's ImagesLock object
+func (w *wrap) GetImagesLock() (*imagelock.ImagesLock, error) {
+	return w.chart.GetImagesLock()
 }
 
 // AbsFilePath returns the absolute path to the Chart relative file name

--- a/testdata/scenarios/no-images-chart/Chart.yaml.tmpl
+++ b/testdata/scenarios/no-images-chart/Chart.yaml.tmpl
@@ -1,0 +1,16 @@
+name: {{or .Name "WordPress"}}
+version: {{or .Version "1.0.0"}}
+annotations:
+    category: CMS
+    licenses: Apache-2.0
+appVersion: {{if .AppVersion}}{{.AppVersion}}{{else}}6.2.2{{end}}
+{{if .Dependencies }}
+{{if gt (len .Dependencies) 0 }}
+dependencies:
+{{- range .Dependencies}}
+    - name: {{.Name}}
+      repository: {{.Repository}}
+      version: {{.Version}}
+{{end -}}
+{{end}}
+{{end}}

--- a/testdata/scenarios/no-images-chart/Images.lock.tmpl
+++ b/testdata/scenarios/no-images-chart/Images.lock.tmpl
@@ -1,0 +1,1 @@
+{{include "imagelock.partial.tmpl" . }}

--- a/testdata/scenarios/no-images-chart/imagelock.partial.tmpl
+++ b/testdata/scenarios/no-images-chart/imagelock.partial.tmpl
@@ -1,0 +1,10 @@
+apiVersion: v0
+kind: ImagesLock
+metadata:
+  generatedAt: "2023-07-13T16:30:33.284125307Z"
+  generatedBy: Distribution Tooling for Helm
+chart:
+  name: {{.Name}}
+  version: 1.0.0
+  appVersion: {{if .AppVersion}}{{.AppVersion}}{{else}}6.2.2{{end}}
+images: []


### PR DESCRIPTION
The output of `dt wrap` and `dt images pull` shows the following message when there are no images to pull:

```
       ✔  All images pulled successfully
```

Instead, we are going to show a warning when there are no images to pull:

```
       ⚠️  No images found in Images.lock
```