### PR TITLE
Remove non-required `ClientOptResolver` option usage

### DIFF
--- a/pkg/artifacts/helm.go
+++ b/pkg/artifacts/helm.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/remotes/docker"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"

--- a/pkg/artifacts/helm.go
+++ b/pkg/artifacts/helm.go
@@ -200,7 +200,7 @@ func PullChart(chartURL, version string, destDir string, opts ...RegistryClientO
 func PushChart(tarFile string, pushChartURL string, opts ...RegistryClientOption) error {
 	cfg := &action.Configuration{}
 
-	registryClient, err, logout := registryClientWithLogin(pushChartURL, opts...)
+	registryClient, logout, err := registryClientWithLogin(pushChartURL, opts...)
 	if err != nil {
 		return fmt.Errorf("failed getting a logged in registry client: %w", err)
 	}
@@ -223,7 +223,7 @@ func PushChart(tarFile string, pushChartURL string, opts ...RegistryClientOption
 func showRemoteHelmChart(chartURL string, version string, opts ...RegistryClientOption) (string, error) {
 	cfg := &action.Configuration{}
 
-	registryClient, err, logout := registryClientWithLogin(chartURL, opts...)
+	registryClient, logout, err := registryClientWithLogin(chartURL, opts...)
 	if err != nil {
 		return "", fmt.Errorf("failed getting a logged in registry client: %w", err)
 	}

--- a/pkg/artifacts/helm.go
+++ b/pkg/artifacts/helm.go
@@ -106,17 +106,10 @@ func getRegistryClientWrap(cfg *RegistryClientConfig) (*registryClientWrap, erro
 			return nil, fmt.Errorf("error closing credentials file: %w", err)
 		}
 		opts = append(opts, registry.ClientOptCredentialsFile(f.Name()))
-		revOpts := docker.ResolverOptions{}
-		authz := docker.NewDockerAuthorizer(docker.WithAuthCreds(func(_ string) (string, string, error) {
-			return cfg.Auth.Username, cfg.Auth.Password, nil
-		}))
-		revOpts.Hosts = docker.ConfigureDefaultRegistries(
-			docker.WithAuthorizer(authz),
-			docker.WithPlainHTTP(func(_ string) (bool, error) { return cfg.UsePlainHTTP, nil }),
-		)
-		rev := docker.NewResolver(revOpts)
 
-		opts = append(opts, registry.ClientOptResolver(rev))
+		if cfg.UsePlainHTTP {
+			opts = append(opts, registry.ClientOptPlainHTTP())
+		}
 	}
 	r, err := registry.NewClient(opts...)
 	if err != nil {


### PR DESCRIPTION
In [Kubeapps](https://kubeapps.dev/), we needed to add a new `ClientOptResolver`option in the Helm project ([context here](https://github.com/vmware-tanzu/kubeapps/issues/4194)). However, this is mostly for tests and other non-typical use-cases.
The current `NewClient` function in Helm is setting the required options in the autorizer, so there is no need to manually set the resolver ([see the code](https://github.com/helm/helm/blob/c5698e5e51949c4ab86a22c5566fac20e13d6f73/pkg/registry/client.go#L73-L155))

This PR is mainly remove those redundant piece of code, so that `ClientOptResolver` is not used anymore.

The rationale behind the change is in https://github.com/helm/helm/pull/12310#discussion_r1501065719. In short, this is blocking a potential upgrade from ORAS v1 to v2 at Helm's side.
