### PR TITLE
Use go 1.21.9 for CVE-2023-45288 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.21.9
 
       - name: Set Golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set Golang
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: 1.21
+          go-version: 1.21.9
 
       - name: Build
         run: make build

--- a/cmd/dt/version.go
+++ b/cmd/dt/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is the tool version
-var Version = "0.4.1"
+var Version = "0.4.0"
 
 // BuildDate is the tool build date
 var BuildDate = ""

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "dt"
-version: "0.4.1"
+version: "0.4.0"
 usage: "Distribution Tooling for Helm"
 description: "Distribution Tooling for Helm"
 command: "$HELM_PLUGIN_DIR/bin/dt"


### PR DESCRIPTION
- Update the CI to use Go 1.21.9 for CVE-2023-45288 instead of the cached 1.21.8 version
- Revert 26fa9c21a587ba686d6bca10ecde199bf3c01a4c preparing new release