### PR TITLE
This branch adds support for nested helm dependencies

### DIFF
--- a/pkg/chartutils/values.go
+++ b/pkg/chartutils/values.go
@@ -181,8 +181,8 @@ func parseValuesImageElement(data map[string]interface{}) *ValuesImageElement {
 	for _, k := range imageElementKeys {
 		v, ok := data[k]
 		if !ok {
-			// digest is optional
-			if k == "digest" {
+			// digest and registry are optional
+			if k == "digest" || k == "registry" {
 				continue
 			}
 			return nil
@@ -192,10 +192,6 @@ func parseValuesImageElement(data map[string]interface{}) *ValuesImageElement {
 			return nil
 		}
 		elemData[k] = vStr
-	}
-	// An empty registry may be acceptable, but not an empty repository
-	if elemData["repository"] == "" {
-		return nil
 	}
 	return valuesImageElementFromMap(elemData)
 }

--- a/pkg/relocator/imagelock.go
+++ b/pkg/relocator/imagelock.go
@@ -9,10 +9,10 @@ import (
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/utils"
 )
 
-func relocateImages(images imagelock.ImageList, prefix string) (count int, err error) {
+func relocateImages(images imagelock.ImageList, newRegistry string) (count int, err error) {
 	var allErrors error
 	for _, img := range images {
-		norm, err := utils.RelocateImageURL(img.Image, prefix, true)
+		norm, err := utils.RelocateImageRegistry(img.Image, newRegistry, true)
 		if err != nil {
 			allErrors = errors.Join(allErrors, err)
 			continue
@@ -24,8 +24,8 @@ func relocateImages(images imagelock.ImageList, prefix string) (count int, err e
 }
 
 // RelocateLock rewrites the images urls in the provided lock using prefix
-func RelocateLock(lock *imagelock.ImagesLock, prefix string) (*RelocationResult, error) {
-	count, err := relocateImages(lock.Images, prefix)
+func RelocateLock(lock *imagelock.ImagesLock, newRegistry string) (*RelocationResult, error) {
+	count, err := relocateImages(lock.Images, newRegistry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to relocate Images.lock file: %v", err)
 	}
@@ -37,12 +37,12 @@ func RelocateLock(lock *imagelock.ImagesLock, prefix string) (*RelocationResult,
 }
 
 // RelocateLockFile relocates images urls in the provided Images.lock using prefix
-func RelocateLockFile(file string, prefix string) error {
+func RelocateLockFile(file string, newRegistry string) error {
 	lock, err := imagelock.FromYAMLFile(file)
 	if err != nil {
 		return fmt.Errorf("failed to load Images.lock: %v", err)
 	}
-	result, err := RelocateLock(lock, prefix)
+	result, err := RelocateLock(lock, newRegistry)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -194,7 +194,21 @@ func TestRelocateImageURL(t *testing.T) {
 				url:    "example.com:80/foo/bar/bitnami/app",
 				prefix: newReg,
 			},
-			want: fmt.Sprintf("%s/bitnami/app", newReg),
+			want: fmt.Sprintf("%s/foo/bar/bitnami/app", newReg),
+		},
+		"Replaces registry with doubly nested repository prefex": {
+			args: args{
+				url:    "www.example.com/docker/abc/imagename",
+				prefix: newReg,
+			},
+			want: fmt.Sprintf("%s/docker/abc/imagename", newReg),
+		},
+		"Replaces registry with triply nested repository prefix": {
+			args: args{
+				url:    "www.example.com/docker/abc/testimages/imagename",
+				prefix: newReg,
+			},
+			want: fmt.Sprintf("%s/docker/abc/testimages/imagename", newReg),
 		},
 		"Replaces library repositoy": {
 			args: args{
@@ -213,7 +227,7 @@ func TestRelocateImageURL(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := RelocateImageURL(tt.args.url, tt.args.prefix, tt.args.includeIndentifier)
+			got, err := RelocateImageRegistry(tt.args.url, tt.args.prefix, tt.args.includeIndentifier)
 			validateError(t, tt.expectedErr, err)
 
 			if got != tt.want {

--- a/testdata/scenarios/chart1/charts/common/charts/common2/Chart.yaml
+++ b/testdata/scenarios/chart1/charts/common/charts/common2/Chart.yaml
@@ -10,8 +10,3 @@ icon: https://bitnami.com/downloads/logos/bitnami-mark.png
 name: common
 type: library
 version: 2.6.0
-dependencies:
-  - name: common2
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 2.x.x
-


### PR DESCRIPTION
The previous implementation had a recursive function but it terminated after one level 
This branch adds support for nested repository urls - the previous implementation only supported a single level

Resolves: #67