### PR TITLE
Propagate insecure

### DIFF
--- a/cmd/dt/auth_test.go
+++ b/cmd/dt/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware-labs/distribution-tooling-for-helm/internal/testutil"
+
 	"helm.sh/helm/v3/pkg/repo/repotest"
 )
 

--- a/cmd/dt/pull/pull.go
+++ b/cmd/dt/pull/pull.go
@@ -63,6 +63,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 						chartutils.WithContext(ctx),
 						chartutils.WithProgressBar(childLog.ProgressBar()),
 						chartutils.WithArtifactsDir(chart.ImageArtifactsDir()),
+						chartutils.WithInsecureMode(cfg.Insecure),
 					); err != nil {
 						return childLog.Failf("%v", err)
 					}
@@ -109,7 +110,6 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 
 func pullImages(chart wrapping.Lockable, imagesDir string, opts ...chartutils.Option) error {
 	lock, err := chart.GetImagesLock()
-
 	if err != nil {
 		return fmt.Errorf("failed to read Images.lock file")
 	}

--- a/cmd/dt/wrap/wrap.go
+++ b/cmd/dt/wrap/wrap.go
@@ -214,7 +214,6 @@ func ResolveInputChartPath(inputPath string, cfg *Config) (string, error) {
 	var err error
 
 	tmpDir, err := cfg.GetTemporaryDirectory()
-
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -342,6 +341,7 @@ func pullImages(wrap wrapping.Wrap, cfg *Config) error {
 				chartutils.WithAuth(cfg.ContainerRegistryAuth.Username, cfg.ContainerRegistryAuth.Password),
 				chartutils.WithArtifactsDir(wrap.ImageArtifactsDir()),
 				chartutils.WithProgressBar(childLog.ProgressBar()),
+				chartutils.WithInsecureMode(cfg.Insecure),
 			); err != nil {
 				return childLog.Failf("%v", err)
 			}
@@ -439,7 +439,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 	var platforms []string
 	var fetchArtifacts bool
 	var carvelize bool
-	var examples = `  # Wrap a Helm chart from a local folder
+	examples := `  # Wrap a Helm chart from a local folder
   $ dt wrap examples/mariadb
 
   # Wrap a Helm chart in an OCI registry
@@ -476,7 +476,6 @@ This command will pull all the container images and wrap it into a single tarbal
 				WithOutputFile(outputFile),
 				WithTempDirectory(tmpDir),
 			)
-
 			if err != nil {
 				if _, ok := err.(*log.LoggedError); ok {
 					// We already logged it, lets be less verbose

--- a/cmd/dt/wrap_test.go
+++ b/cmd/dt/wrap_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"helm.sh/helm/v3/pkg/repo/repotest"
 
 	"github.com/vmware-labs/distribution-tooling-for-helm/cmd/dt/wrap"

--- a/internal/testutil/oci.go
+++ b/internal/testutil/oci.go
@@ -10,8 +10,9 @@ import (
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
-	"helm.sh/helm/v3/pkg/repo/repotest"
 	"oras.land/oras-go/v2/content/oci"
+
+	"helm.sh/helm/v3/pkg/repo/repotest"
 
 	"github.com/distribution/distribution/v3/configuration"
 	"github.com/distribution/distribution/v3/registry"

--- a/pkg/artifacts/helm.go
+++ b/pkg/artifacts/helm.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/remotes/docker"
+
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"


### PR DESCRIPTION
When invoking `dt images pull` and `dt wrap` the `--insecure` option do not seems to be propagated.
Add flag passing to both commands