### PR TITLE
Skip image references

### DIFF
--- a/cmd/dt/relocate/relocate.go
+++ b/cmd/dt/relocate/relocate.go
@@ -12,6 +12,7 @@ import (
 // NewCmd builds a new relocate command
 func NewCmd(cfg *config.Config) *cobra.Command {
 	valuesFiles := []string{"values.yaml"}
+	skipImageRefs := false
 	cmd := &cobra.Command{
 		Use:   "relocate CHART_PATH OCI_URI",
 		Short: "Relocates a Helm chart",
@@ -35,6 +36,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 					relocator.WithLog(l), relocator.Recursive,
 					relocator.WithAnnotationsKey(cfg.AnnotationsKey),
 					relocator.WithValuesFiles(valuesFiles...),
+					relocator.WithSkipImageRefs(skipImageRefs),
 				)
 			}); err != nil {
 				return l.Failf("failed to relocate Helm chart %q: %w", chartPath, err)
@@ -46,6 +48,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringSliceVar(&valuesFiles, "values", valuesFiles, "values files to relocate images (can specify multiple)")
+	cmd.PersistentFlags().BoolVar(&skipImageRefs, "skip-image-refs", skipImageRefs, "Skip updating image references in values.yaml and Images.lock")
 
 	return cmd
 }

--- a/pkg/relocator/chart.go
+++ b/pkg/relocator/chart.go
@@ -26,6 +26,11 @@ type RelocationResult struct {
 }
 
 func relocateChart(chart *cu.Chart, prefix string, cfg *RelocateConfig) error {
+	var allErrors error
+	if cfg.SkipImageRefs {
+		return allErrors
+	}
+
 	valuesReplRes, err := relocateValues(chart, prefix)
 	if err != nil {
 		return fmt.Errorf("failed to relocate chart: %v", err)
@@ -38,8 +43,6 @@ func relocateChart(chart *cu.Chart, prefix string, cfg *RelocateConfig) error {
 			}
 		}
 	}
-
-	var allErrors error
 
 	// TODO: Compare annotations with values replacements
 	annotationsRelocResult, err := relocateAnnotations(chart, prefix)

--- a/pkg/relocator/chart_test.go
+++ b/pkg/relocator/chart_test.go
@@ -84,4 +84,66 @@ func TestRelocateChartDir(t *testing.T) {
 		assert.Equal(t, expectedData, relocatedImagesData)
 
 	})
+
+	// create a new chart dir to reset for the SkipImageRef tests
+	chartDir = sb.TempFile()
+	require.NoError(t, tu.RenderScenario(scenarioDir, chartDir, map[string]interface{}{"ServerURL": serverURL}))
+	err = RelocateChartDir(chartDir, "", WithValuesFiles(valuesFiles...), WithSkipImageRefs(true))
+	require.NoError(t, err)
+
+	t.Run("Values Relocated SkipImageRef", func(t *testing.T) {
+		for _, valuesFile := range valuesFiles {
+			t.Logf("checking %s file", valuesFile)
+			data, err := os.ReadFile(filepath.Join(chartDir, valuesFile))
+			require.NoError(t, err)
+			relocatedValues, err := tu.NormalizeYAML(string(data))
+			require.NoError(t, err)
+
+			expectedData, err := tu.RenderTemplateFile(filepath.Join(scenarioDir, fmt.Sprintf("%s.tmpl", valuesFile)), map[string]string{"ServerURL": serverURL})
+			require.NoError(t, err)
+
+			expectedValues, err := tu.NormalizeYAML(expectedData)
+			require.NoError(t, err)
+			assert.Equal(t, expectedValues, relocatedValues)
+		}
+	})
+
+	t.Run("Annotations Relocated ", func(t *testing.T) {
+		c, err := loader.Load(chartDir)
+		require.NoError(t, err)
+
+		relocatedAnnotations, err := tu.NormalizeYAML(c.Metadata.Annotations["images"])
+		require.NoError(t, err)
+
+		require.NotEqual(t, relocatedAnnotations, "")
+
+		expectedData, err := tu.RenderTemplateFile(filepath.Join(scenarioDir, "images.partial.tmpl"), map[string]string{"ServerURL": serverURL})
+		require.NoError(t, err)
+
+		expectedAnnotations, err := tu.NormalizeYAML(expectedData)
+		require.NoError(t, err)
+		assert.Equal(t, expectedAnnotations, relocatedAnnotations)
+	})
+
+	t.Run("ImageLock Relocated SkipImageRef", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join(chartDir, "Images.lock"))
+		assert.NoError(t, err)
+		var lockData map[string]interface{}
+
+		require.NoError(t, yaml.Unmarshal(data, &lockData))
+
+		imagesElemData, err := yaml.Marshal(lockData["images"])
+		require.NoError(t, err)
+
+		relocatedImagesData, err := tu.NormalizeYAML(string(imagesElemData))
+		require.NoError(t, err)
+
+		expectedData, err := tu.RenderTemplateFile(filepath.Join(scenarioDir, "lock_images.partial.tmpl"), map[string]string{"ServerURL": serverURL})
+		require.NoError(t, err)
+		expectedData, err = tu.NormalizeYAML(expectedData)
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedData, relocatedImagesData)
+
+	})
 }

--- a/pkg/relocator/options.go
+++ b/pkg/relocator/options.go
@@ -13,6 +13,7 @@ type RelocateConfig struct {
 	Log              log.Logger
 	RelocateLockFile bool
 	Recursive        bool
+	SkipImageRefs    bool
 	ValuesFiles      []string
 }
 
@@ -20,6 +21,7 @@ type RelocateConfig struct {
 func NewRelocateConfig(opts ...RelocateOption) *RelocateConfig {
 	cfg := &RelocateConfig{
 		Log:              silentLog.NewLogger(),
+		SkipImageRefs:    false,
 		RelocateLockFile: true,
 		ImageLockConfig:  *imagelock.NewImagesLockConfig(),
 		ValuesFiles:      []string{"values.yaml"},
@@ -43,6 +45,13 @@ func Recursive(c *RelocateConfig) {
 func WithAnnotationsKey(str string) func(rc *RelocateConfig) {
 	return func(rc *RelocateConfig) {
 		rc.ImageLockConfig.AnnotationsKey = str
+	}
+}
+
+// WithSkipImageRefs configures the skipImageRefs configuration
+func WithSkipImageRefs(skipimagerefs bool) func(rc *RelocateConfig) {
+	return func(rc *RelocateConfig) {
+		rc.SkipImageRefs = skipimagerefs
 	}
 }
 


### PR DESCRIPTION
Adding options that allow a wrapped helm chart to not fetch images and also an option to not push images when syncing a wrapped chart to a destination repo.  Also added an option to not update image references in the values.yaml.  I plan on opening up a PR to charts-syncer later on to use these options with it as there are times when I do not want it to sync images.