### PR TITLE
fix(docs): remove typo

### DIFF
--- a/pkg/relocator/chart.go
+++ b/pkg/relocator/chart.go
@@ -96,7 +96,7 @@ func RelocateChartDir(chartPath string, prefix string, opts ...RelocateOption) e
 	if cfg.Recursive {
 		for _, dep := range chart.Dependencies() {
 			if err := relocateChart(dep, prefix, cfg); err != nil {
-				allErrors = errors.Join(allErrors, fmt.Errorf("failed to reloacte Helm SubChart %q: %v", dep.Chart().ChartFullPath(), err))
+				allErrors = errors.Join(allErrors, fmt.Errorf("failed to relocate Helm SubChart %q: %v", dep.Chart().ChartFullPath(), err))
 			}
 		}
 	}


### PR DESCRIPTION
Minor typo fix

```
failed to reloacte Helm SubChart "chainloop/charts/postgresql": failed to write values.yaml:
```