### PR TITLE
SPIKE: fix pullImage for when source already contains digest

### DIFF
--- a/pkg/chartutils/images.go
+++ b/pkg/chartutils/images.go
@@ -288,8 +288,11 @@ func getImageLayoutDir(imagesDir string, dgst imagelock.DigestInfo) string {
 
 func pullImage(image string, digest imagelock.DigestInfo, imagesDir string, o crane.Options) (string, error) {
 	imgDir := getImageLayoutDir(imagesDir, digest)
-
-	src := fmt.Sprintf("%s@%s", image, digest.Digest)
+	
+	var src = fmt.Sprintf("%s@%s", image, digest.Digest)
+	if strings.Contains(image, string(digest.Digest)) {
+		src = image
+	}
 	ref, err := name.ParseReference(src, o.Name...)
 	if err != nil {
 		return "", fmt.Errorf("parsing reference %q: %w", src, err)

--- a/pkg/chartutils/images.go
+++ b/pkg/chartutils/images.go
@@ -288,8 +288,7 @@ func getImageLayoutDir(imagesDir string, dgst imagelock.DigestInfo) string {
 
 func pullImage(image string, digest imagelock.DigestInfo, imagesDir string, o crane.Options) (string, error) {
 	imgDir := getImageLayoutDir(imagesDir, digest)
-	
-	var src = fmt.Sprintf("%s@%s", image, digest.Digest)
+	src := fmt.Sprintf("%s@%s", image, digest.Digest)
 	if strings.Contains(image, string(digest.Digest)) {
 		src = image
 	}


### PR DESCRIPTION
This fixes the current implementation to correctly pullImage when the source image from annotations already contains the image digest.


(note this was generated from dt annotate command where the values specify the image digest)

values.yaml
```
image2:
  registry: example.com
  repository: deploy/aaaaaa/service-a
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: 0.3.0
  digest: sha256:f43290f7f2e3c3c8281bee512d216b7c604fd92501b3b4522df9333b1921f867
```

generated Images.lock

```
apiVersion: v0
kind: ImagesLock
metadata:
  generatedAt: "2024-09-24T07:19:33.65058Z"
  generatedBy: Distribution Tooling for Helm
chart:
  name: test-chart1
  version: 0.1.0
  appVersion: 1.16.0
images:
  - name: service-a
    image: example.com/deploy/aaaaaa/service-a:0.3.0@sha256:f43290f7f2e3c3c8281bee512d216b7c604fd92501b3b4522df9333b1921f867
    chart: test-chart1
    digests:
      - digest: sha256:f43290f7f2e3c3c8281bee512d216b7c604fd92501b3b4522df9333b1921f867
        arch: linux/amd64
```

Failure
```
    ✘  failed to pull images: failed to pull image "service-a": parsing reference " example.com/deploy/aaaaaa/service-a:0.3.0@sha256:f43290f7f2e3c3c8281bee512d216b7c604fd92501b3b4522df9333b1921f867@sha256:f43290f7f2e3c3c8281bee512d216b7c604fd92501b3b4522df9333b1921f867": could not parse reference:  example.com/deploy/aaaaaa/service-a:0.3.0@sha256:f43290f7f2e3c3c8281bee512d216b7c604fd92501b3b4522df9333b1921f867@sha256:f43290f7f2e3c3c8281bee512d216b7c604fd92501b3b4522df9333b1921f867
```



