### PR TITLE
feat: Bump Go version to 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,9 @@ jobs:
           version: v3.12.1
 
       - name: Set Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: 1.24.2
+          go-version: '^1.25'
 
       - name: Set Golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set Golang
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: 1.24.2
+          go-version: '^1.25'
 
       - name: Build
         run: make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-labs/distribution-tooling-for-helm
 
-go 1.24.2
+go 1.25
 
 require (
 	github.com/DataDog/go-tuf v1.0.2-0.5.2


### PR DESCRIPTION
### Description of the change

Bump Go version to `1.25`.

### Benefits

Keep the project updated.

### Possible drawbacks

None
