### PR TITLE
fix: Pass through --annotations-key to unwrap

### DIFF
--- a/cmd/dt/unwrap/unwrap.go
+++ b/cmd/dt/unwrap/unwrap.go
@@ -491,6 +491,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 				WithContext(ctx),
 				WithVersion(version),
 				WithInteractive(true),
+				WithAnnotationsKey(cfg.AnnotationsKey),
 				WithInsecure(cfg.Insecure),
 				WithTempDirectory(tempDir),
 				WithUsePlainHTTP(cfg.UsePlainHTTP),


### PR DESCRIPTION
Arg wasn't passed through properly causing it to be ignored

Fixes #119