### PR TITLE
fix: do not resolve image digests if --skip-pull-images flag is set

### DIFF
--- a/cmd/dt/wrap/wrap.go
+++ b/cmd/dt/wrap/wrap.go
@@ -304,6 +304,7 @@ func validateWrapLock(wrap wrapping.Wrap, cfg *Config) error {
 			func() error {
 				return lock.Create(chart.RootDir(), lockFile, silent.NewLogger(),
 					imagelock.WithAnnotationsKey(cfg.AnnotationsKey),
+					imagelock.WithSkipImageDigestResolution(cfg.SkipPullImages),
 					imagelock.WithInsecure(cfg.Insecure),
 					imagelock.WithAuth(cfg.ContainerRegistryAuth.Username, cfg.ContainerRegistryAuth.Password),
 					imagelock.WithPlatforms(cfg.Platforms),

--- a/pkg/imagelock/image.go
+++ b/pkg/imagelock/image.go
@@ -138,17 +138,19 @@ func GetImagesFromChartAnnotations(c *chart.Chart, cfg *Config) (ImageList, erro
 	return images, nil
 }
 
-// getDigestedImagesFromChartAnnotations reads the images from the chart annotations and fills up
+// getImagesFromChartAnnotations reads the images from the chart annotations and fills up
 // the per-architecture digests for the images based on the remote registry
-func getDigestedImagesFromChartAnnotations(c *chart.Chart, cfg *Config) (ImageList, error) {
+func getImagesFromChartAnnotations(c *chart.Chart, cfg *Config) (ImageList, error) {
 	var allErrors error
 	images, err := GetImagesFromChartAnnotations(c, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image list: %w", err)
 	}
-	for _, image := range images {
-		if err := image.FetchDigests(cfg); err != nil {
-			allErrors = errors.Join(allErrors, fmt.Errorf("failed to fetch image %q digests: %w", image.Name, err))
+	if !cfg.SkipImageDigestResolution {
+		for _, image := range images {
+			if err := image.FetchDigests(cfg); err != nil {
+				allErrors = errors.Join(allErrors, fmt.Errorf("failed to fetch image %q digests: %w", image.Name, err))
+			}
 		}
 	}
 	return images, allErrors

--- a/pkg/imagelock/lock.go
+++ b/pkg/imagelock/lock.go
@@ -143,7 +143,7 @@ func GenerateFromChart(chartPath string, opts ...Option) (*ImagesLock, error) {
 // populateImagesFromChart populates the ImagesLock with images and digests from the given chart and its dependencies.
 func populateImagesFromChart(imgLock *ImagesLock, chart *chart.Chart, cfg *Config) error {
 
-	images, err := getDigestedImagesFromChartAnnotations(chart, cfg)
+	images, err := getImagesFromChartAnnotations(chart, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to process Helm chart %q images: %v", chart.Name(), err)
 	}

--- a/pkg/imagelock/options.go
+++ b/pkg/imagelock/options.go
@@ -12,11 +12,12 @@ type Auth struct {
 
 // Config defines configuration options for ImageLock functions
 type Config struct {
-	InsecureMode   bool
-	AnnotationsKey string
-	Context        context.Context
-	Auth           Auth
-	Platforms      []string
+	InsecureMode              bool
+	AnnotationsKey            string
+	Context                   context.Context
+	Auth                      Auth
+	Platforms                 []string
+	SkipImageDigestResolution bool
 }
 
 // NewImagesLockConfig returns a new ImageLockConfig with default values
@@ -75,5 +76,12 @@ func WithContext(ctx context.Context) func(ic *Config) {
 func WithAnnotationsKey(str string) func(ic *Config) {
 	return func(ic *Config) {
 		ic.AnnotationsKey = str
+	}
+}
+
+// WithSkipImageDigestResolution configures the SkipImageDigestResolution of the Config
+func WithSkipImageDigestResolution(skipImageResolution bool) func(ic *Config) {
+	return func(ic *Config) {
+		ic.SkipImageDigestResolution = skipImageResolution
 	}
 }


### PR DESCRIPTION
Avoid resolving the image digests when creating the image-lock file if the --skip-pull-images flag is set. 

It is possible that some of the images referenced by a chart are not accessible anymore (eg bitnami deletion of images from dockerhub).

FIxes #123

In this case an images-lock will pass from this:

```
images:
  - name: apache-exporter
    image: registry-1.docker.io/bitnami/apache-exporter:1.0.10-r23-debian-12
    chart: wordpress
    digests:
      - digest: sha256:4cbf8e78e38b71da07c20ec32363c585a2bb1da49b9072b8457e502d1c9da681
        arch: linux/amd64
      - digest: sha256:6d1d72d70a4ac6cf735436ba3b9b2da65870d43a05df03e935f1d86c67a486a0
        arch: linux/arm64
```

to this:

```
  - name: apache-exporter
    image: registry-1.docker.io/bitnami/apache-exporter:1.0.10-r23-debian-12
    chart: wordpress
    digests: []
```