### PR TITLE
fix basic auth in some registries

### DIFF
--- a/cmd/dt/version.go
+++ b/cmd/dt/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is the tool version
-var Version = "0.4.11"
+var Version = "0.4.12"
 
 // BuildDate is the tool build date
 var BuildDate = ""

--- a/pkg/artifacts/helm.go
+++ b/pkg/artifacts/helm.go
@@ -3,15 +3,12 @@ package artifacts
 import (
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"oras.land/oras-go/v2/registry/remote/auth"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
@@ -98,16 +95,9 @@ func getRegistryClientWrap(cfg *RegistryClientConfig) (*registryClientWrap, erro
 		opts = append(opts, registry.ClientOptHTTPClient(httpClient))
 	}
 	if cfg.Auth.Username != "" && cfg.Auth.Password != "" {
-		basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", cfg.Auth.Username, cfg.Auth.Password)))
 		opts = append(
 			opts,
 			registry.ClientOptBasicAuth(cfg.Auth.Username, cfg.Auth.Password),
-			registry.ClientOptAuthorizer(auth.Client{
-				Client: httpClient,
-				Header: http.Header{
-					"Authorization": []string{basicAuth},
-				},
-			}),
 		)
 	}
 	r, err := registry.NewClient(opts...)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "dt"
-version: "0.4.11"
+version: "0.4.12"
 usage: "Distribution Tooling for Helm"
 description: "Distribution Tooling for Helm"
 command: "$HELM_PLUGIN_DIR/bin/dt"


### PR DESCRIPTION
Don't set a custom authorizer and let helm library manage it. This used to work fine until we updated the helm library to version 3.18.x. In that version, there were changes in the auth mechanism that conflicts with the custom authorizer set in this tool. 

Additionally, we update the version to cut a new release.