### PR TITLE
Support for replacing image registry in the slice

### DIFF
--- a/pkg/chartutils/values.go
+++ b/pkg/chartutils/values.go
@@ -194,6 +194,13 @@ func findImageElementsInMap(data map[string]interface{}, id string) []*ValuesIma
 		if v, ok := v.(map[string]interface{}); ok {
 			elements = append(elements, findImageElementsInMap(v, fmt.Sprintf("%s.%s", id, k))...)
 		}
+		if v, ok := v.([]interface{}); ok {
+			for i, v := range v {
+				if v, ok := v.(map[string]interface{}); ok {
+					elements = append(elements, findImageElementsInMap(v, fmt.Sprintf("%s.%s[%d]", id, k, i))...)
+				}
+			}
+		}
 	}
 	return elements
 }


### PR DESCRIPTION
I extracted a portion of my charts values yaml as shown below. I added an images annotation to the chart.yaml annotations, then executed dt wrap and dt unwrap. I found that other image addresses were successfully replaced, but these two images were not successfully replaced.

```yaml
  containers:
    - name: "vllm"
      image: 
         registry: docker.io
         repository: vllm/vllm-openai
         tag: v0.13.0
      modelCommand: imageDefault
    - name: "routing-proxy"  
      image:
         registry: ghcr.io
         repository: llm-d/llm-d-routing-sidecar
         tag: v0.5.0
```

Through debugging the code, I discovered that dt only searches for paths of `map[string]interface{}` in YAML and does not search for `[]interface{}` paths. This prevents dt from locating the two images I mentioned earlier.

Based on these findings, I modified the code, rebuilt the dt binary, and the tests passed.


I'm not certain if this description is accurate. Feel free to reach out if you have any questions.

