### PR TITLE
feat: make image repository preservation configurable in relocation

### DIFF
--- a/cmd/dt/unwrap/unwrap.go
+++ b/cmd/dt/unwrap/unwrap.go
@@ -49,6 +49,7 @@ type Config struct {
 	Auth                  Auth
 	ContainerRegistryAuth Auth
 	ValuesFiles           []string
+	PreserveRepository    bool
 
 	// Interactive enables interacting with the user
 	Interactive bool
@@ -220,15 +221,23 @@ func WithValuesFiles(files ...string) func(c *Config) {
 	}
 }
 
+// WithPreserveRepository configures the PreserveRepository of the Config
+func WithPreserveRepository(preserve bool) func(c *Config) {
+	return func(c *Config) {
+		c.PreserveRepository = preserve
+	}
+}
+
 // NewConfig returns a new WrapConfig with default values
 func NewConfig(opts ...Option) *Config {
 	cfg := &Config{
-		Context:        context.Background(),
-		TempDirectory:  "",
-		logger:         logrus.NewSectionLogger(),
-		AnnotationsKey: imagelock.DefaultAnnotationsKey,
-		Platforms:      []string{},
-		ValuesFiles:    []string{"values.yaml"},
+		Context:            context.Background(),
+		TempDirectory:      "",
+		logger:             logrus.NewSectionLogger(),
+		AnnotationsKey:     imagelock.DefaultAnnotationsKey,
+		Platforms:          []string{},
+		ValuesFiles:        []string{"values.yaml"},
+		PreserveRepository: true,
 	}
 
 	for _, opt := range opts {
@@ -302,6 +311,7 @@ func unwrapChart(inputChart, registryURL, pushChartURL string, opts ...Option) (
 			wrap.ChartDir(), registryURL, relocator.WithLog(l),
 			relocator.Recursive, relocator.WithAnnotationsKey(cfg.AnnotationsKey), relocator.WithValuesFiles(cfg.ValuesFiles...),
 			relocator.WithSkipImageRelocation(cfg.SkipImageRelocation),
+			relocator.WithPreserveRepository(cfg.PreserveRepository),
 		)
 	}); err != nil {
 		return "", l.Failf("failed to relocate %q: %w", chartPath, err)
@@ -444,7 +454,8 @@ func pushChartImagesAndVerify(ctx context.Context, wrap wrapping.Wrap, cfg *Conf
 
 		return verify.Lock(wrap.ChartDir(), lockFile, verify.Config{
 			Insecure: cfg.Insecure, AnnotationsKey: cfg.AnnotationsKey,
-			Auth: verify.Auth{Username: cfg.ContainerRegistryAuth.Username, Password: cfg.ContainerRegistryAuth.Password},
+			PreserveRepository: cfg.PreserveRepository,
+			Auth:               verify.Auth{Username: cfg.ContainerRegistryAuth.Username, Password: cfg.ContainerRegistryAuth.Password},
 		})
 	}); err != nil {
 		return fmt.Errorf("failed to verify Helm chart Images.lock: %w", err)

--- a/cmd/dt/verify/verify.go
+++ b/cmd/dt/verify/verify.go
@@ -21,9 +21,10 @@ type Auth struct {
 
 // Config defines the configuration of the verify command
 type Config struct {
-	AnnotationsKey string
-	Insecure       bool
-	Auth           Auth
+	AnnotationsKey     string
+	Insecure           bool
+	PreserveRepository bool
+	Auth               Auth
 }
 
 // Lock verifies the images in an Images.lock
@@ -46,6 +47,7 @@ func Lock(chartPath string, lockFile string, cfg Config) error {
 		imagelock.WithContext(context.Background()),
 		imagelock.WithAuth(cfg.Auth.Username, cfg.Auth.Password),
 		imagelock.WithInsecure(cfg.Insecure),
+		imagelock.WithPreserveRepository(cfg.PreserveRepository),
 	)
 
 	if err != nil {
@@ -89,7 +91,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 			}
 
 			if err := l.ExecuteStep("Verifying Images.lock", func() error {
-				return Lock(chartPath, lockFile, Config{Insecure: cfg.Insecure, AnnotationsKey: cfg.AnnotationsKey})
+				return Lock(chartPath, lockFile, Config{Insecure: cfg.Insecure, AnnotationsKey: cfg.AnnotationsKey, PreserveRepository: true})
 			}); err != nil {
 				return l.Failf("failed to verify %q lock: %w", chartPath, err)
 			}

--- a/pkg/chartutils/options.go
+++ b/pkg/chartutils/options.go
@@ -17,16 +17,17 @@ type Auth struct {
 
 // Configuration defines configuration settings used in chartutils functions
 type Configuration struct {
-	AnnotationsKey string
-	Log            dtlog.Logger
-	Context        context.Context
-	ProgressBar    dtlog.ProgressBar
-	ArtifactsDir   string
-	FetchArtifacts bool
-	MaxRetries     int
-	InsecureMode   bool
-	Auth           Auth
-	ValuesFiles    []string
+	AnnotationsKey     string
+	Log                dtlog.Logger
+	Context            context.Context
+	ProgressBar        dtlog.ProgressBar
+	ArtifactsDir       string
+	FetchArtifacts     bool
+	MaxRetries         int
+	InsecureMode       bool
+	Auth               Auth
+	ValuesFiles        []string
+	PreserveRepository bool
 }
 
 // WithInsecureMode configures Insecure transport
@@ -84,15 +85,16 @@ func WithProgressBar(pb dtlog.ProgressBar) func(cfg *Configuration) {
 // NewConfiguration returns a new Configuration
 func NewConfiguration(opts ...Option) *Configuration {
 	cfg := &Configuration{
-		AnnotationsKey: imagelock.DefaultAnnotationsKey,
-		Context:        context.Background(),
-		ProgressBar:    silent.NewProgressBar(),
-		ArtifactsDir:   "",
-		FetchArtifacts: false,
-		MaxRetries:     3,
-		Log:            silent.NewLogger(),
-		InsecureMode:   false,
-		ValuesFiles:    []string{"values.yaml"},
+		AnnotationsKey:     imagelock.DefaultAnnotationsKey,
+		Context:            context.Background(),
+		ProgressBar:        silent.NewProgressBar(),
+		ArtifactsDir:       "",
+		FetchArtifacts:     false,
+		MaxRetries:         3,
+		Log:                silent.NewLogger(),
+		InsecureMode:       false,
+		ValuesFiles:        []string{"values.yaml"},
+		PreserveRepository: true,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -122,5 +124,12 @@ func WithAnnotationsKey(str string) func(cfg *Configuration) {
 func WithValuesFiles(files ...string) func(cfg *Configuration) {
 	return func(cfg *Configuration) {
 		cfg.ValuesFiles = files
+	}
+}
+
+// WithPreserveRepository configures whether to preserve repository paths during relocation
+func WithPreserveRepository(preserve bool) func(cfg *Configuration) {
+	return func(cfg *Configuration) {
+		cfg.PreserveRepository = preserve
 	}
 }

--- a/pkg/chartutils/values.go
+++ b/pkg/chartutils/values.go
@@ -119,8 +119,9 @@ func (v *ValuesImageElement) isOriginalRepositoryBare() bool {
 }
 
 // Relocate modifies the ValuesImageElement Registry and Repository based on the provided prefix
-func (v *ValuesImageElement) Relocate(prefix string) error {
-	newURL, err := utils.RelocateImageURL(v.URL(), prefix, false, true)
+// and preserveRepository setting
+func (v *ValuesImageElement) Relocate(prefix string, preserveRepository bool) error {
+	newURL, err := utils.RelocateImageURL(v.URL(), prefix, false, preserveRepository)
 	if err != nil {
 		return fmt.Errorf("failed to relocate: %v", err)
 	}

--- a/pkg/chartutils/values_test.go
+++ b/pkg/chartutils/values_test.go
@@ -13,12 +13,13 @@ func TestValuesImageElement_Relocate(t *testing.T) {
 		name             string
 		elem             *ValuesImageElement
 		prefix           string
+		preserveRepo     bool
 		expectedErr      bool
 		expectedRegistry string
 		expectedRepo     string
 	}{
 		{
-			name: "relocate with registry field with default project",
+			name: "relocate with registry field with default project (preserve=true)",
 			elem: &ValuesImageElement{
 				Registry:    "docker.io",
 				Repository:  "nginx",
@@ -26,12 +27,27 @@ func TestValuesImageElement_Relocate(t *testing.T) {
 				foundFields: []string{"registry", "repository", "tag"},
 			},
 			prefix:           "registry.example.com/myrepo",
+			preserveRepo:     true,
 			expectedErr:      false,
 			expectedRegistry: "registry.example.com",
 			expectedRepo:     "myrepo/library/nginx",
 		},
 		{
-			name: "relocate with registry field with non default project",
+			name: "relocate with registry field with default project (preserve=false)",
+			elem: &ValuesImageElement{
+				Registry:    "docker.io",
+				Repository:  "nginx",
+				Tag:         "latest",
+				foundFields: []string{"registry", "repository", "tag"},
+			},
+			prefix:           "registry.example.com/myrepo",
+			preserveRepo:     false,
+			expectedErr:      false,
+			expectedRegistry: "registry.example.com",
+			expectedRepo:     "myrepo/nginx",
+		},
+		{
+			name: "relocate with registry field with non default project (preserve=true)",
 			elem: &ValuesImageElement{
 				Registry:    "docker.io",
 				Repository:  "redpandadata/redpanda",
@@ -39,63 +55,134 @@ func TestValuesImageElement_Relocate(t *testing.T) {
 				foundFields: []string{"registry", "repository", "tag"},
 			},
 			prefix:           "007439368137.dkr.ecr.us-east-2.amazonaws.com/kafka",
+			preserveRepo:     true,
 			expectedErr:      false,
 			expectedRegistry: "007439368137.dkr.ecr.us-east-2.amazonaws.com",
 			expectedRepo:     "kafka/redpandadata/redpanda",
 		},
 		{
-			name: "relocate without registry field",
+			name: "relocate with registry field with non default project (preserve=false)",
+			elem: &ValuesImageElement{
+				Registry:    "docker.io",
+				Repository:  "redpandadata/redpanda",
+				Tag:         "latest",
+				foundFields: []string{"registry", "repository", "tag"},
+			},
+			prefix:           "007439368137.dkr.ecr.us-east-2.amazonaws.com/kafka",
+			preserveRepo:     false,
+			expectedErr:      false,
+			expectedRegistry: "007439368137.dkr.ecr.us-east-2.amazonaws.com",
+			expectedRepo:     "kafka/redpanda",
+		},
+		{
+			name: "relocate without registry field (preserve=true)",
 			elem: &ValuesImageElement{
 				Repository:  "quay.io/cert-manager-controller",
 				Tag:         "latest",
 				foundFields: []string{"repository", "tag"},
 			},
 			prefix:           "007439368137.dkr.ecr.us-east-2.amazonaws.com",
+			preserveRepo:     true,
 			expectedErr:      false,
 			expectedRegistry: "",
 			expectedRepo:     "007439368137.dkr.ecr.us-east-2.amazonaws.com/cert-manager-controller",
 		},
 		{
-			name: "relocate without registry field and non default project",
+			name: "relocate without registry field (preserve=false)",
+			elem: &ValuesImageElement{
+				Repository:  "quay.io/cert-manager-controller",
+				Tag:         "latest",
+				foundFields: []string{"repository", "tag"},
+			},
+			prefix:           "007439368137.dkr.ecr.us-east-2.amazonaws.com",
+			preserveRepo:     false,
+			expectedErr:      false,
+			expectedRegistry: "",
+			expectedRepo:     "007439368137.dkr.ecr.us-east-2.amazonaws.com/cert-manager-controller",
+		},
+		{
+			name: "relocate without registry field and non default project (preserve=true)",
 			elem: &ValuesImageElement{
 				Repository:  "quay.io/jetstack/cert-manager-controller",
 				Tag:         "latest",
 				foundFields: []string{"repository", "tag"},
 			},
 			prefix:           "007439368137.dkr.ecr.us-east-2.amazonaws.com",
+			preserveRepo:     true,
 			expectedErr:      false,
 			expectedRegistry: "",
 			expectedRepo:     "007439368137.dkr.ecr.us-east-2.amazonaws.com/jetstack/cert-manager-controller",
 		},
 		{
-			name: "relocate without registry field with default project",
+			name: "relocate without registry field and non default project (preserve=false)",
+			elem: &ValuesImageElement{
+				Repository:  "quay.io/jetstack/cert-manager-controller",
+				Tag:         "latest",
+				foundFields: []string{"repository", "tag"},
+			},
+			prefix:           "007439368137.dkr.ecr.us-east-2.amazonaws.com",
+			preserveRepo:     false,
+			expectedErr:      false,
+			expectedRegistry: "",
+			expectedRepo:     "007439368137.dkr.ecr.us-east-2.amazonaws.com/cert-manager-controller",
+		},
+		{
+			name: "relocate without registry field with default project (preserve=true)",
 			elem: &ValuesImageElement{
 				Repository:  "nginx",
 				Tag:         "latest",
 				foundFields: []string{"repository", "tag"},
 			},
 			prefix:           "localhost:5000/myrepo",
+			preserveRepo:     true,
 			expectedErr:      false,
 			expectedRegistry: "localhost:5000",
 			expectedRepo:     "myrepo/library/nginx",
 		},
 		{
-			name: "relocate without registry field with non default project",
+			name: "relocate without registry field with default project (preserve=false)",
+			elem: &ValuesImageElement{
+				Repository:  "nginx",
+				Tag:         "latest",
+				foundFields: []string{"repository", "tag"},
+			},
+			prefix:           "localhost:5000/myrepo",
+			preserveRepo:     false,
+			expectedErr:      false,
+			expectedRegistry: "localhost:5000",
+			expectedRepo:     "myrepo/nginx",
+		},
+		{
+			name: "relocate without registry field with non default project (preserve=true)",
 			elem: &ValuesImageElement{
 				Repository:  "redpandadata/redpanda",
 				Tag:         "latest",
 				foundFields: []string{"repository", "tag"},
 			},
 			prefix:           "localhost:5000/kafka",
+			preserveRepo:     true,
 			expectedErr:      false,
 			expectedRegistry: "localhost:5000",
 			expectedRepo:     "kafka/redpandadata/redpanda",
+		},
+		{
+			name: "relocate without registry field with non default project (preserve=false)",
+			elem: &ValuesImageElement{
+				Repository:  "redpandadata/redpanda",
+				Tag:         "latest",
+				foundFields: []string{"repository", "tag"},
+			},
+			prefix:           "localhost:5000/kafka",
+			preserveRepo:     false,
+			expectedErr:      false,
+			expectedRegistry: "localhost:5000",
+			expectedRepo:     "kafka/redpanda",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.elem.Relocate(tt.prefix)
+			err := tt.elem.Relocate(tt.prefix, tt.preserveRepo)
 
 			if tt.expectedErr && err == nil {
 				t.Error("Expected error but got none")

--- a/pkg/imagelock/options.go
+++ b/pkg/imagelock/options.go
@@ -18,14 +18,16 @@ type Config struct {
 	Auth                      Auth
 	Platforms                 []string
 	SkipImageDigestResolution bool
+	PreserveRepository        bool
 }
 
 // NewImagesLockConfig returns a new ImageLockConfig with default values
 func NewImagesLockConfig(opts ...Option) *Config {
 	cfg := &Config{
-		AnnotationsKey: DefaultAnnotationsKey,
-		Context:        context.Background(),
-		Platforms:      make([]string, 0),
+		AnnotationsKey:     DefaultAnnotationsKey,
+		Context:            context.Background(),
+		Platforms:          make([]string, 0),
+		PreserveRepository: true,
 	}
 
 	for _, opt := range opts {
@@ -83,5 +85,12 @@ func WithAnnotationsKey(str string) func(ic *Config) {
 func WithSkipImageDigestResolution(skipImageResolution bool) func(ic *Config) {
 	return func(ic *Config) {
 		ic.SkipImageDigestResolution = skipImageResolution
+	}
+}
+
+// WithPreserveRepository configures the PreserveRepository of the Config
+func WithPreserveRepository(preserve bool) func(ic *Config) {
+	return func(ic *Config) {
+		ic.PreserveRepository = preserve
 	}
 }

--- a/pkg/relocator/annotations.go
+++ b/pkg/relocator/annotations.go
@@ -12,19 +12,20 @@ func RelocateAnnotations(chartDir string, prefix string, opts ...chartutils.Opti
 	if err != nil {
 		return "", fmt.Errorf("failed to relocate annotations: %w", err)
 	}
-	res, err := relocateAnnotations(c, prefix)
+	cfg := chartutils.NewConfiguration(opts...)
+	res, err := relocateAnnotations(c, prefix, cfg.PreserveRepository)
 	if err != nil {
 		return "", fmt.Errorf("failed to relocate annotations: %w", err)
 	}
 	return string(res.Data), nil
 }
 
-func relocateAnnotations(c *chartutils.Chart, prefix string) (*RelocationResult, error) {
+func relocateAnnotations(c *chartutils.Chart, prefix string, preserveRepository bool) (*RelocationResult, error) {
 	images, err := c.GetAnnotatedImages()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read images from annotations: %v", err)
 	}
-	count, err := relocateImages(images, prefix, true)
+	count, err := relocateImages(images, prefix, preserveRepository)
 	if err != nil {
 		return nil, fmt.Errorf("failed to relocate annotations: %v", err)
 	}

--- a/pkg/relocator/chart.go
+++ b/pkg/relocator/chart.go
@@ -31,7 +31,7 @@ func relocateChart(chart *cu.Chart, prefix string, cfg *RelocateConfig) error {
 		return allErrors
 	}
 
-	valuesReplRes, err := relocateValues(chart, prefix)
+	valuesReplRes, err := relocateValues(chart, prefix, cfg.PreserveRepository)
 	if err != nil {
 		return fmt.Errorf("failed to relocate chart: %v", err)
 	}
@@ -45,7 +45,7 @@ func relocateChart(chart *cu.Chart, prefix string, cfg *RelocateConfig) error {
 	}
 
 	// TODO: Compare annotations with values replacements
-	annotationsRelocResult, err := relocateAnnotations(chart, prefix)
+	annotationsRelocResult, err := relocateAnnotations(chart, prefix, cfg.PreserveRepository)
 	if err != nil {
 		allErrors = errors.Join(allErrors, fmt.Errorf("failed to relocate Helm chart: %v", err))
 	} else {
@@ -61,7 +61,7 @@ func relocateChart(chart *cu.Chart, prefix string, cfg *RelocateConfig) error {
 
 	lockFile := chart.LockFilePath()
 	if utils.FileExists(lockFile) {
-		err = RelocateLockFile(lockFile, prefix, true)
+		err = RelocateLockFile(lockFile, prefix, cfg.PreserveRepository)
 		if err != nil {
 			allErrors = errors.Join(allErrors, fmt.Errorf("failed to relocate Images.lock file: %v", err))
 		}

--- a/pkg/relocator/options.go
+++ b/pkg/relocator/options.go
@@ -15,6 +15,7 @@ type RelocateConfig struct {
 	Recursive           bool
 	SkipImageRelocation bool
 	ValuesFiles         []string
+	PreserveRepository  bool
 }
 
 // NewRelocateConfig returns a new RelocateConfig with default settings
@@ -23,6 +24,7 @@ func NewRelocateConfig(opts ...RelocateOption) *RelocateConfig {
 		Log:                 silentLog.NewLogger(),
 		SkipImageRelocation: false,
 		RelocateLockFile:    true,
+		PreserveRepository:  true,
 		ImageLockConfig:     *imagelock.NewImagesLockConfig(),
 		ValuesFiles:         []string{"values.yaml"},
 	}
@@ -73,5 +75,15 @@ func WithLog(l dtlog.Logger) func(rc *RelocateConfig) {
 func WithValuesFiles(files ...string) func(rc *RelocateConfig) {
 	return func(rc *RelocateConfig) {
 		rc.ValuesFiles = files
+	}
+}
+
+// WithPreserveRepository controls whether the source repository path is preserved in the
+// relocated URL. When true, the last part of the repository is preserved (e.g., "bitnami/wordpress").
+// When false, only the image base name is kept (e.g., "wordpress").
+// Use false for respecting destination URLs that already include repository structure.
+func WithPreserveRepository(preserve bool) func(rc *RelocateConfig) {
+	return func(rc *RelocateConfig) {
+		rc.PreserveRepository = preserve
 	}
 }

--- a/pkg/relocator/values.go
+++ b/pkg/relocator/values.go
@@ -9,7 +9,7 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
-func relocateValuesData(valuesFile string, valuesData []byte, prefix string) (*RelocationResult, error) {
+func relocateValuesData(valuesFile string, valuesData []byte, prefix string, preserveRepository bool) (*RelocationResult, error) {
 	valuesMap, err := chartutil.ReadValues(valuesData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Helm chart values: %v", err)
@@ -24,7 +24,7 @@ func relocateValuesData(valuesFile string, valuesData []byte, prefix string) (*R
 
 	data := make(map[string]string, 0)
 	for _, e := range imageElems {
-		if err = e.Relocate(prefix); err != nil {
+		if err = e.Relocate(prefix, preserveRepository); err != nil {
 			return nil, fmt.Errorf("unexpected error relocating: %v", err)
 		}
 		for k, v := range e.YamlReplaceMap() {
@@ -38,14 +38,14 @@ func relocateValuesData(valuesFile string, valuesData []byte, prefix string) (*R
 	return &RelocationResult{Name: valuesFile, Data: relocatedData, Count: len(imageElems)}, nil
 }
 
-func relocateValues(c *cu.Chart, prefix string) ([]*RelocationResult, error) {
+func relocateValues(c *cu.Chart, prefix string, preserveRepository bool) ([]*RelocationResult, error) {
 	result := make([]*RelocationResult, 0, len(c.ValuesFiles()))
 	for _, values := range c.ValuesFiles() {
 		if values == nil {
 			result = append(result, &RelocationResult{})
 			continue
 		}
-		res, err := relocateValuesData(values.Name, values.Data, prefix)
+		res, err := relocateValuesData(values.Name, values.Data, prefix, preserveRepository)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -131,6 +131,13 @@ var relocateRepoRe = regexp.MustCompile("^.*?/(([^/]+/)?[^/]+)$")
 // Use true for Helm chart wraps where the repository structure is meaningful, and false
 // for standalone container image wraps where only the image name matters.
 func RelocateImageURL(url string, prefix string, includeIdentifier, preserveRepository bool) (string, error) {
+	if strings.TrimSpace(url) == "" {
+		return "", fmt.Errorf("failed to relocate url: image URL cannot be empty")
+	}
+	if strings.TrimSpace(prefix) == "" {
+		return "", fmt.Errorf("failed to relocate url: prefix cannot be empty")
+	}
+
 	ref, err := name.ParseReference(url)
 	if err != nil {
 		return "", fmt.Errorf("failed to relocate url: %v", err)
@@ -143,7 +150,7 @@ func RelocateImageURL(url string, prefix string, includeIdentifier, preserveRepo
 		// We will preserve the last part of the repository
 		match := relocateRepoRe.FindStringSubmatch(normalizedURL)
 		if match == nil {
-			return "", fmt.Errorf("failed to parse normalized URL")
+			return "", fmt.Errorf("failed to parse normalized URL: could not extract repository from %q", normalizedURL)
 		}
 		newURL = fmt.Sprintf("%s/%s", strings.TrimRight(prefix, "/"), match[1])
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -232,6 +232,34 @@ func TestRelocateImageURL(t *testing.T) {
 			},
 			expectedErr: "failed to relocate url: could not parse reference",
 		},
+		"Fails on empty URL": {
+			args: args{
+				url:    "",
+				prefix: newReg,
+			},
+			expectedErr: "failed to relocate url: image URL cannot be empty",
+		},
+		"Fails on whitespace-only URL": {
+			args: args{
+				url:    "   ",
+				prefix: newReg,
+			},
+			expectedErr: "failed to relocate url: image URL cannot be empty",
+		},
+		"Fails on empty prefix": {
+			args: args{
+				url:    "bitnami/wordpress:latest",
+				prefix: "",
+			},
+			expectedErr: "failed to relocate url: prefix cannot be empty",
+		},
+		"Fails on whitespace-only prefix": {
+			args: args{
+				url:    "bitnami/wordpress:latest",
+				prefix: "   ",
+			},
+			expectedErr: "failed to relocate url: prefix cannot be empty",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

This change introduces a **`PreserveRepository` setting** end-to-end for image relocation: chart values, annotations, `Images.lock`, image-lock generation used by verify, and unwrap’s relocation + post-push verify step. When enabled (the default), relocated URLs keep meaningful repository path segments (e.g. `bitnami/wordpress`); when disabled, only the base image name is used under the target prefix.

## Motivation

Relocation behavior previously mixed fixed assumptions. Exposing **`PreserveRepository` as configuration** lets API callers align relocation with their registry layout and use cases (e.g. full repo path vs. flattened names) without changing the default behavior for existing users.

## What changed

- **Relocator** (`RelocateConfig`): new `PreserveRepository` (default `true`), `WithPreserveRepository`, threaded through `relocateValues`, `relocateAnnotations`, and `RelocateLockFile`.
- **Chart utils**: `Configuration` gains `PreserveRepository` (default `true`) and `WithPreserveRepository`; `ValuesImageElement.Relocate` now takes `preserveRepository` and passes it to `utils.RelocateImageURL`.
- **Image lock**: `imagelock.Config` includes `PreserveRepository` (default `true`) and `WithPreserveRepository`.
- **Unwrap**: `unwrap.Config` includes `PreserveRepository` (default `true`), `WithPreserveRepository`, passed to `relocator.RelocateChartDir` and into `verify.Lock` after image push.
- **Verify**: `verify.Config` includes `PreserveRepository`; CLI `verify` continues to use **`PreserveRepository: true`** when calling `Lock` so CLI behavior matches the previous default.
- **Utils**: `RelocateImageURL` rejects empty or whitespace-only URL/prefix; improved error when the repository cannot be extracted under `preserveRepository=true`.

## Tests

- Expanded `TestValuesImageElement_Relocate` for **`preserveRepo` true and false** across registry/repository combinations.
- Added `TestRelocateImageURL` cases for **empty/whitespace URL and prefix**.

## Backward compatibility

Defaults preserve the prior effective behavior for chart relocation (**`PreserveRepository: true`**). Library callers can opt into `false` where flattening is desired.