### PR TITLE
feature(artifacts): preserve cosign signatures per platform through wrap/unwrap

### DIFF
--- a/cmd/dt/unwrap_test.go
+++ b/cmd/dt/unwrap_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware-labs/distribution-tooling-for-helm/cmd/dt/unwrap"
+	"github.com/vmware-labs/distribution-tooling-for-helm/cmd/dt/wrap"
 	tu "github.com/vmware-labs/distribution-tooling-for-helm/internal/testutil"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/artifacts"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/dtlog/logrus"
+	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/utils"
 
 	"helm.sh/helm/v3/pkg/repo/repotest"
 )
@@ -426,4 +428,120 @@ func (suite *CmdSuite) TestEndToEnd() {
 			})
 		})
 	}
+}
+
+// TestInnerManifestSignaturePreservedThroughWrapUnwrap verifies that a cosign signature
+// created for an inner platform manifest (rather than the manifest list) is correctly
+// preserved through wrap+unwrap with the per-architecture storage model:
+//
+//  1. Pull side (dt wrap): PullImageSignatures stores the inner-manifest sig at
+//     <tag>.<arch>.sig/ (e.g. latest.linux_amd64.sig/) rather than the shared <tag>.sig/.
+//
+//  2. Push side (dt unwrap): PushImageSignatures pushes <tag>.<arch>.sig/ under the
+//     matching sha256-<inner-digest>.sig tag on the target registry, so CRI-O/containerd
+//     runtimes that resolve the manifest list and verify the selected platform's inner
+//     manifest can locate and validate the correct signature.
+func (suite *CmdSuite) TestInnerManifestSignaturePreservedThroughWrapUnwrap() {
+	require := suite.Require()
+	assert := suite.Assert()
+
+	silentLog := log.New(io.Discard, "", 0)
+	s := httptest.NewServer(registry.New(registry.Logger(silentLog)))
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	require.NoError(err)
+	serverURL := u.Host
+
+	sb := suite.sb
+	scenarioDir := "../../testdata/scenarios/complete-chart"
+	chartName := "test"
+	version := "1.0.0"
+	imageName := "test"
+
+	srcNS := "inner-sig-src"
+	dstNS := "inner-sig-dst"
+	srcRegistry := fmt.Sprintf("%s/%s", serverURL, srcNS)
+	targetRegistry := fmt.Sprintf("%s/%s", serverURL, dstNS)
+
+	certDir, err := sb.Mkdir(sb.TempFile(), 0755)
+	require.NoError(err)
+	keyFile, pubKey, err := tu.GenerateCosignCertificateFiles(certDir)
+	require.NoError(err)
+
+	// Push the image WITHOUT manifest-list-level signing so that only the inner platform
+	// manifest digest tag is present on the source registry after we sign below.
+	images, err := tu.AddSampleImagesToRegistry(imageName, srcRegistry)
+	require.NoError(err)
+	require.NotEmpty(images)
+	require.NotEmpty(images[0].Digests)
+
+	// Locate the linux/amd64 inner platform manifest digest.
+	var amd64Hex, amd64Full string
+	for _, dgst := range images[0].Digests {
+		if dgst.Arch == "linux/amd64" {
+			amd64Hex = dgst.Digest.Hex()
+			amd64Full = dgst.Digest.String()
+			break
+		}
+	}
+	require.NotEmpty(amd64Hex, "linux/amd64 digest must be present in the sample image set")
+
+	// Sign the inner platform manifest by its digest — this is the standard cosign workflow
+	// used by Kubernetes clusters with sigstoreSigned admission policy, where the runtime
+	// resolves the manifest list and then looks for sha256-<inner-digest>.sig.
+	innerSrcRef := fmt.Sprintf("%s/%s@%s", srcRegistry, imageName, amd64Full)
+	require.NoError(tu.CosignImage(innerSrcRef, keyFile))
+
+	// Set up the Helm chart referencing the source images.
+	chartDir := sb.TempFile()
+	require.NoError(tu.RenderScenario(scenarioDir, chartDir,
+		map[string]interface{}{"ServerURL": srcRegistry, "Images": images, "Name": chartName, "Version": version, "RepositoryURL": srcRegistry},
+	))
+
+	// Wrap with --fetch-artifacts. PullImageSignatures should detect sha256-<amd64-hex>.sig
+	// on the source and save it to latest.linux_amd64.sig/ inside the bundle.
+	tempWrapFile := sb.TempFile() + ".wrap.tgz"
+	l1 := logrus.NewSectionLogger()
+	l1.SetWriter(io.Discard)
+	_, err = wrap.Chart(chartDir,
+		wrap.WithLogger(l1),
+		wrap.WithUsePlainHTTP(true),
+		wrap.WithFetchArtifacts(true),
+		wrap.WithOutputFile(tempWrapFile),
+	)
+	require.NoError(err)
+
+	// Extract the bundle and confirm the per-arch sig OCI layout was captured.
+	// With the new per-arch storage model the sig is stored at <tag>.<arch>.sig/ rather than
+	// the shared <tag>.sig/ (which is reserved for the manifest-list level signature).
+	wrapExtractDir := sb.TempFile()
+	require.NoError(utils.Untar(tempWrapFile, wrapExtractDir, utils.TarConfig{StripComponents: 1}))
+	sigArtifactDir := filepath.Join(wrapExtractDir, "artifacts", "images", chartName, imageName, "latest.linux_amd64.sig")
+	require.DirExists(sigArtifactDir, "per-arch sig artifact must be present in the wrap bundle at latest.linux_amd64.sig/")
+
+	// Unwrap to the target registry. PushImageSignatures should push the per-arch sig stored
+	// at latest.linux_amd64.sig/ under sha256-<amd64-inner-digest>.sig on the target.
+	l2 := logrus.NewSectionLogger()
+	l2.SetWriter(io.Discard)
+	_, err = unwrap.Chart(tempWrapFile, targetRegistry, "",
+		unwrap.WithLogger(l2),
+		unwrap.WithUsePlainHTTP(true),
+		unwrap.WithSayYes(true),
+	)
+	require.NoError(err)
+
+	// With PreserveRepository=true (default) the source namespace is appended to the target.
+	targetImageRepo := fmt.Sprintf("%s/%s/%s/%s", serverURL, dstNS, srcNS, imageName)
+
+	tags, err := artifacts.ListTags(context.Background(), targetImageRepo, crane.Insecure)
+	require.NoError(err)
+
+	expectedSigTag := fmt.Sprintf("sha256-%s.sig", amd64Hex)
+	assert.Contains(tags, expectedSigTag,
+		"sig tag for the linux/amd64 inner manifest digest must exist on the target registry after unwrap")
+
+	// Confirm cosign can validate the signature on the target using the inner digest reference.
+	innerTargetRef := fmt.Sprintf("%s/%s/%s/%s@%s", serverURL, dstNS, srcNS, imageName, amd64Full)
+	assert.NoError(tu.CosignVerifyImage(innerTargetRef, pubKey),
+		"cosign signature validation must succeed for the inner manifest on the target registry")
 }

--- a/pkg/artifacts/artifacts.go
+++ b/pkg/artifacts/artifacts.go
@@ -139,6 +139,25 @@ func getImageArtifactsDir(image *imagelock.ChartImage, destDir string, suffix st
 	return filepath.Join(destDir, image.Chart, image.Name, fmt.Sprintf("%s.%s", imgTag, suffix)), nil
 }
 
+// sanitizeArch converts an arch string (e.g. "linux/amd64") into a filesystem-safe
+// segment by replacing "/" with "_" (e.g. "linux_amd64").
+func sanitizeArch(arch string) string {
+	return strings.ReplaceAll(arch, "/", "_")
+}
+
+// getImageArchArtifactsDir returns the local path for a per-architecture artifact.
+// The path follows the convention <destDir>/<chart>/<name>/<tag>.<sanitizedArch>.<suffix>/,
+// keeping each platform's artifact distinct from the manifest-list level artifact.
+func getImageArchArtifactsDir(image *imagelock.ChartImage, destDir string, suffix string, arch string, opts ...Option) (string, error) {
+	imgTag, _, err := getImageTagAndDigest(image.Image, opts...)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image reference: %w", err)
+	}
+
+	return filepath.Join(destDir, image.Chart, image.Name,
+		fmt.Sprintf("%s.%s.%s", imgTag, sanitizeArch(arch), suffix)), nil
+}
+
 func pushArtifact(ctx context.Context, image string, dest string, tagSuffix string, opts ...Option) (string, error) {
 	cfg := NewConfig(opts...)
 	if !utils.FileExists(dest) {
@@ -176,6 +195,44 @@ func pushArtifact(ctx context.Context, image string, dest string, tagSuffix stri
 	newImg := fmt.Sprintf("%s:%s", repo, tag)
 
 	switch t := img.(type) {
+	case v1.Image:
+		return tag, crane.Push(t, newImg, craneOpts...)
+	default:
+		return "", fmt.Errorf("unsupported image type %T", t)
+	}
+}
+
+// pushArtifactWithHex pushes the local oci-layout artifact at dest to the registry under the
+// tag sha256-<hex>.<tagSuffix>, using the provided hex directly rather than resolving the
+// image reference against the remote registry. This is used to push signatures under
+// content-addressed (inner platform manifest) digest tags that remain stable across registries.
+func pushArtifactWithHex(ctx context.Context, image string, dest string, hex string, tagSuffix string, opts ...Option) (string, error) {
+	cfg := NewConfig(opts...)
+	if !utils.FileExists(dest) {
+		return "", ErrLocalArtifactNotExist
+	}
+	craneOpts := []crane.Option{crane.WithContext(ctx)}
+
+	if cfg.Auth.Password != "" && cfg.Auth.Username != "" {
+		craneOpts = append(craneOpts, crane.WithAuth(&authn.Basic{
+			Username: cfg.Auth.Username,
+			Password: cfg.Auth.Password,
+		}))
+	}
+	repo, err := getImageRepository(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to get image repository: %w", err)
+	}
+
+	tag := fmt.Sprintf("sha256-%s.%s", hex, tagSuffix)
+	artifact, err := loadImage(dest)
+	if err != nil {
+		return "", err
+	}
+
+	newImg := fmt.Sprintf("%s:%s", repo, tag)
+
+	switch t := artifact.(type) {
 	case v1.Image:
 		return tag, crane.Push(t, newImg, craneOpts...)
 	default:
@@ -231,16 +288,50 @@ func PushImageMetadata(ctx context.Context, image *imagelock.ChartImage, destDir
 	return pushAssetMetadata(ctx, imageRef, dir, opts...)
 }
 
-// PushImageSignatures pushes a oci-layout directory to the registry as the image signature
+// PushImageSignatures pushes all locally stored cosign signatures for an image to the
+// target registry. It handles two separate cases independently:
+//
+//  1. Manifest-list level signature: if <tag>.sig/ exists locally, it is pushed under the
+//     sha256-<resolved-target-manifest-list-digest>.sig tag.
+//
+//  2. Per-architecture inner manifest signatures: for each platform digest in image.Digests,
+//     if <tag>.<sanitizedArch>.sig/ exists locally (e.g. latest.linux_amd64.sig/), it is
+//     pushed under sha256-<inner-digest>.sig.
+//
+// Returns ErrLocalArtifactNotExist when no local signature exists for any of the above cases.
 func PushImageSignatures(ctx context.Context, image *imagelock.ChartImage, destDir string, opts ...Option) error {
 	imageRef := image.Image
-	dir, err := getImageArtifactsDir(image, destDir, "sig", opts...)
+	pushedAny := false
+
+	// 1. Push manifest-list level sig under the resolved target manifest-list digest tag.
+	manifestListDir, err := getImageArtifactsDir(image, destDir, "sig", opts...)
 	if err != nil {
 		return fmt.Errorf("failed to obtain signature location: %v", err)
 	}
-	_, err = pushArtifact(ctx, imageRef, dir, "sig", opts...)
-	if err != nil {
-		return err
+	if utils.FileExists(manifestListDir) {
+		if _, err := pushArtifact(ctx, imageRef, manifestListDir, "sig", opts...); err != nil {
+			return err
+		}
+		pushedAny = true
+	}
+
+	// 2. Push each per-architecture inner manifest sig under sha256-<inner-digest>.sig.
+	// Each arch sig has its own correct payload digest, so it is only pushed under the tag
+	// that matches its payload — no cross-platform sig duplication.
+	for _, dgst := range image.Digests {
+		archDir, err := getImageArchArtifactsDir(image, destDir, "sig", dgst.Arch, opts...)
+		if err != nil || !utils.FileExists(archDir) {
+			continue
+		}
+		innerHex := dgst.Digest.Hex()
+		if _, err := pushArtifactWithHex(ctx, imageRef, archDir, innerHex, "sig", opts...); err != nil {
+			return err
+		}
+		pushedAny = true
+	}
+
+	if !pushedAny {
+		return ErrLocalArtifactNotExist
 	}
 	return nil
 }
@@ -341,16 +432,84 @@ func pullAssetMetadata(ctx context.Context, imageRef string, dir string, opts ..
 	return nil
 }
 
-// PullImageSignatures pulls the image signature and stores it locally as an oci-layout
+// pullArchSignatures pulls the per-architecture inner manifest signatures for all platforms
+// listed in image.Digests, saving each to <tag>.<sanitizedArch>.sig/. It returns true when
+// at least one sig was saved successfully.
+func pullArchSignatures(ctx context.Context, image *imagelock.ChartImage, destDir string, opts ...Option) bool {
+	cfg := NewConfig(opts...)
+	craneOpts := []crane.Option{crane.WithContext(ctx)}
+	if cfg.InsecureMode {
+		craneOpts = append(craneOpts, crane.Insecure)
+	}
+	if cfg.Auth.Password != "" && cfg.Auth.Username != "" {
+		craneOpts = append(craneOpts, crane.WithAuth(&authn.Basic{
+			Username: cfg.Auth.Username,
+			Password: cfg.Auth.Password,
+		}))
+	}
+	o := crane.GetOptions(craneOpts...)
+
+	repo, err := getImageRepository(image.Image)
+	if err != nil {
+		return false
+	}
+
+	foundAny := false
+	for _, dgst := range image.Digests {
+		innerHex := dgst.Digest.Hex()
+		tag := fmt.Sprintf("sha256-%s.sig", innerHex)
+
+		exists, err := TagExist(ctx, repo, tag, o)
+		if err != nil || !exists {
+			continue
+		}
+		archDir, err := getImageArchArtifactsDir(image, destDir, "sig", dgst.Arch, opts...)
+		if err != nil {
+			continue
+		}
+		rmt, err := imagelock.GetImageRemoteDescriptor(fmt.Sprintf("%s:%s", repo, tag), craneOpts...)
+		if err != nil {
+			continue
+		}
+		img, err := rmt.Image()
+		if err != nil {
+			continue
+		}
+		if err := saveImage(img, archDir); err != nil {
+			continue
+		}
+		foundAny = true
+	}
+	return foundAny
+}
+
+// PullImageSignatures pulls all available cosign signatures for an image and stores them
+// locally as OCI layouts. It handles two separate cases independently:
+//
+//  1. Manifest-list level signature: if sha256-<manifest-list-digest>.sig exists on the
+//     source, it is saved to <tag>.sig/.
+//
+//  2. Per-architecture inner manifest signatures: for each platform digest in image.Digests,
+//     if sha256-<inner-digest>.sig exists on the source, it is saved to
+//     <tag>.<sanitizedArch>.sig/ (e.g. latest.linux_amd64.sig/).
+//
+// Returns ErrTagDoesNotExist only when no signature at all was found.
 func PullImageSignatures(ctx context.Context, image *imagelock.ChartImage, destDir string, opts ...Option) error {
-	imageRef := image.Image
-	dir, err := getImageArtifactsDir(image, destDir, "sig", opts...)
+	// 1. Manifest-list level sig → <tag>.sig/
+	manifestListDir, err := getImageArtifactsDir(image, destDir, "sig", opts...)
 	if err != nil {
 		return fmt.Errorf("failed to obtain signature location: %v", err)
 	}
-	_, err = pullArtifact(ctx, imageRef, dir, "sig", opts...)
-	if err != nil {
-		return err
+	_, primaryErr := pullArtifact(ctx, image.Image, manifestListDir, "sig", opts...)
+	if primaryErr != nil && primaryErr != ErrTagDoesNotExist {
+		return primaryErr
+	}
+
+	// 2. Per-architecture inner manifest sigs → <tag>.<arch>.sig/
+	archFound := pullArchSignatures(ctx, image, destDir, opts...)
+
+	if primaryErr != nil && !archFound {
+		return ErrTagDoesNotExist
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `dt unwrap` was pushing cosign `.sig` artifacts under
  the reconstructed manifest-list digest on the target, not the
  per-platform inner manifest digests that CRI-O/containerd look for
  during `sigstoreSigned` admission policy verification. Additionally,
  `dt wrap --fetch-artifacts` missed signatures created against inner
  platform manifests (e.g. `cosign sign image@sha256:<inner>`), so
  those signatures never made it into the bundle.

- **New storage model in the wrap bundle**:

  | Source tag | Bundle path | Target tag pushed |
  |---|---|---|
  | `sha256-<manifest-list-digest>.sig` | `<tag>.sig/` | `sha256-<target-manifest-list-digest>.sig` |
  | `sha256-<amd64-inner-digest>.sig` | `<tag>.linux_amd64.sig/` | `sha256-<amd64-inner-digest>.sig` |
  | `sha256-<arm64-inner-digest>.sig` | `<tag>.linux_arm64.sig/` | `sha256-<arm64-inner-digest>.sig` |

- **Changes** (all in `pkg/artifacts/artifacts.go`):
  - `PullImageSignatures` now independently checks the manifest-list
    level tag **and** every inner platform digest tag, storing each
    sig at its own path. Delegates the per-arch loop to the new private
    `pullArchSignatures` helper.
  - `PushImageSignatures` now pushes `<tag>.sig/` only under the
    manifest-list digest tag, and each `<tag>.<arch>.sig/` only under
    its own inner digest tag via `pushArtifactWithHex`.
  - New helpers: `sanitizeArch`, `getImageArchArtifactsDir`,
    `pushArtifactWithHex`.

- **Backward compatibility**: bundles produced before this change
  (containing only `<tag>.sig/`) continue to work — `PushImageSignatures`
  simply skips the per-arch step when no arch-specific files are present.

- Fixes https://github.com/vmware-labs/distribution-tooling-for-helm/issues/148