### PR TITLE
feat: add --preserve-digest flag to wrap/unwrap for byte-for-byte mirroring

### DIFF
--- a/cmd/dt/unwrap/preserve_digest_test.go
+++ b/cmd/dt/unwrap/preserve_digest_test.go
@@ -1,0 +1,182 @@
+package unwrap_test
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-labs/distribution-tooling-for-helm/cmd/dt/unwrap"
+	"github.com/vmware-labs/distribution-tooling-for-helm/cmd/dt/wrap"
+	tu "github.com/vmware-labs/distribution-tooling-for-helm/internal/testutil"
+	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/artifacts"
+	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/dtlog/logrus"
+	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/utils"
+)
+
+func silentLogger() *logrus.SectionLogger {
+	l := logrus.NewSectionLogger()
+	l.SetWriter(io.Discard)
+	return l
+}
+
+// TestPreserveDigestChartManifest proves the core promise of --preserve-digest:
+// a chart originally published to an OCI registry keeps the exact same
+// manifest digest after being wrapped and unwrapped into a different
+// registry, even though today's default wrap/unwrap round trip (untar, copy,
+// re-tar, re-push through Helm's registry client) would change it.
+func TestPreserveDigestChartManifest(t *testing.T) {
+	silentStdLog := log.New(io.Discard, "", 0)
+	s := httptest.NewServer(registry.New(registry.Logger(silentStdLog)))
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+	serverURL := u.Host
+
+	sb := tu.NewSandbox()
+	defer sb.Cleanup()
+
+	chartName := "test"
+	version := "1.0.0"
+
+	// Set up a chart with no images so this test stays focused purely on the
+	// chart artifact's own digest, and publish it to the source registry via
+	// Helm's OWN push action - exactly as if some third party had already
+	// published and (conceptually) signed it.
+	chartDir := sb.TempFile()
+	require.NoError(t, tu.RenderScenario("../../../testdata/scenarios/no-images-chart", chartDir,
+		map[string]any{"Name": chartName, "Version": version},
+	))
+
+	chartTgz := sb.TempFile() + ".tgz"
+	require.NoError(t, utils.Tar(chartDir, chartTgz, utils.TarConfig{Prefix: chartName}))
+
+	srcRepo := "oci://" + serverURL + "/src"
+	require.NoError(t, artifacts.PushChart(chartTgz, srcRepo,
+		artifacts.WithPlainHTTP(true),
+		artifacts.WithTempDir(sb.TempFile()),
+	))
+
+	srcRef := strings.TrimPrefix(srcRepo, "oci://") + "/" + chartName + ":" + version
+	srcDigest, err := crane.Digest(srcRef)
+	require.NoError(t, err)
+
+	// Wrap directly from the OCI source with --preserve-digest.
+	bundleFile := sb.TempFile() + ".wrap.tgz"
+	_, err = wrap.Chart(srcRepo+"/"+chartName,
+		wrap.WithLogger(silentLogger()),
+		wrap.WithUsePlainHTTP(true),
+		wrap.WithVersion(version),
+		wrap.WithPreserveDigest(true),
+		wrap.WithOutputFile(bundleFile),
+	)
+	require.NoError(t, err)
+	require.FileExists(t, bundleFile)
+
+	// The bundle must carry the raw captured OCI artifact, not just the
+	// exploded chart tree.
+	bundleExtractDir := sb.TempFile()
+	require.NoError(t, utils.Untar(bundleFile, bundleExtractDir, utils.TarConfig{StripComponents: 1}))
+	require.FileExists(t, filepath.Join(bundleExtractDir, "chart.oci", "index.json"))
+
+	// Unwrap into a different registry namespace with --preserve-digest.
+	dstRepo := "oci://" + serverURL + "/dst"
+	_, err = unwrap.Chart(bundleFile, dstRepo, "",
+		unwrap.WithLogger(silentLogger()),
+		unwrap.WithUsePlainHTTP(true),
+		unwrap.WithSayYes(true),
+		unwrap.WithPreserveDigest(true),
+	)
+	require.NoError(t, err)
+
+	dstRef := strings.TrimPrefix(dstRepo, "oci://") + "/" + chartName + ":" + version
+	dstDigest, err := crane.Digest(dstRef)
+	require.NoError(t, err)
+
+	require.Equal(t, srcDigest, dstDigest, "chart manifest digest must be preserved end to end")
+}
+
+// TestPreserveDigestChartImagesRelocated proves that --preserve-digest still
+// routes the chart's images to the destination registry passed to
+// `dt unwrap`, instead of silently re-pushing them back to their original
+// source location. This regresses if Images.lock relocation is skipped
+// along with chart content relocation, since both used to live behind the
+// same SkipImageRelocation gate.
+func TestPreserveDigestChartImagesRelocated(t *testing.T) {
+	silentStdLog := log.New(io.Discard, "", 0)
+
+	srcSrv := httptest.NewServer(registry.New(registry.Logger(silentStdLog)))
+	defer srcSrv.Close()
+	srcURL, err := url.Parse(srcSrv.URL)
+	require.NoError(t, err)
+	srcHost := srcURL.Host
+
+	dstSrv := httptest.NewServer(registry.New(registry.Logger(silentStdLog)))
+	defer dstSrv.Close()
+	dstURL, err := url.Parse(dstSrv.URL)
+	require.NoError(t, err)
+	dstHost := dstURL.Host
+
+	sb := tu.NewSandbox()
+	defer sb.Cleanup()
+
+	chartName := "test"
+	version := "1.0.0"
+	imageName := "sample-image"
+
+	images, err := tu.AddSampleImagesToRegistry(imageName, srcHost)
+	require.NoError(t, err)
+	require.Len(t, images, 1)
+
+	chartDir := sb.TempFile()
+	require.NoError(t, tu.RenderScenario("../../../testdata/scenarios/complete-chart", chartDir,
+		map[string]any{"Name": chartName, "Version": version, "ServerURL": srcHost, "RepositoryURL": srcHost, "Images": images},
+	))
+
+	chartTgz := sb.TempFile() + ".tgz"
+	require.NoError(t, utils.Tar(chartDir, chartTgz, utils.TarConfig{Prefix: chartName}))
+
+	srcRepo := "oci://" + srcHost
+	require.NoError(t, artifacts.PushChart(chartTgz, srcRepo,
+		artifacts.WithPlainHTTP(true),
+		artifacts.WithTempDir(sb.TempFile()),
+	))
+
+	srcImageRef := fmt.Sprintf("%s/%s", srcHost, images[0].Image)
+	srcImageDigest, err := crane.Digest(srcImageRef)
+	require.NoError(t, err)
+
+	// Wrap directly from the OCI source with --preserve-digest.
+	bundleFile := sb.TempFile() + ".wrap.tgz"
+	_, err = wrap.Chart(srcRepo+"/"+chartName,
+		wrap.WithLogger(silentLogger()),
+		wrap.WithUsePlainHTTP(true),
+		wrap.WithVersion(version),
+		wrap.WithPreserveDigest(true),
+		wrap.WithOutputFile(bundleFile),
+	)
+	require.NoError(t, err)
+
+	// Unwrap into a completely different registry with --preserve-digest.
+	dstRepo := "oci://" + dstHost
+	_, err = unwrap.Chart(bundleFile, dstRepo, "",
+		unwrap.WithLogger(silentLogger()),
+		unwrap.WithUsePlainHTTP(true),
+		unwrap.WithSayYes(true),
+		unwrap.WithPreserveDigest(true),
+	)
+	require.NoError(t, err)
+
+	dstImageRef := fmt.Sprintf("%s/%s", dstHost, images[0].Image)
+	dstImageDigest, err := crane.Digest(dstImageRef)
+	require.NoError(t, err, "image should have been relocated and pushed to the destination registry")
+	require.Equal(t, srcImageDigest, dstImageDigest, "image manifest digest must be preserved end to end")
+}

--- a/cmd/dt/unwrap/unwrap.go
+++ b/cmd/dt/unwrap/unwrap.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vmware-labs/distribution-tooling-for-helm/cmd/dt/config"
@@ -50,6 +51,7 @@ type Config struct {
 	ContainerRegistryAuth Auth
 	ValuesFiles           []string
 	PreserveRepository    bool
+	PreserveDigest        bool
 
 	// Interactive enables interacting with the user
 	Interactive bool
@@ -228,6 +230,13 @@ func WithPreserveRepository(preserve bool) func(c *Config) {
 	}
 }
 
+// WithPreserveDigest configures the PreserveDigest of the Config
+func WithPreserveDigest(preserveDigest bool) func(c *Config) {
+	return func(c *Config) {
+		c.PreserveDigest = preserveDigest
+	}
+}
+
 // NewConfig returns a new WrapConfig with default values
 func NewConfig(opts ...Option) *Config {
 	cfg := &Config{
@@ -288,6 +297,11 @@ func unwrapChart(inputChart, registryURL, pushChartURL string, opts ...Option) (
 		l.Debugf("Temporary assets kept at %q", tempDir)
 	}
 
+	if cfg.PreserveDigest && !cfg.SkipImageRelocation {
+		l.Debugf("--preserve-digest implies --skip-image-relocation: no chart content will be rewritten")
+		cfg.SkipImageRelocation = true
+	}
+
 	chartPath, err := wrap.ResolveInputChartPath(
 		inputChart,
 		wrap.NewConfig(
@@ -327,7 +341,7 @@ func unwrapChart(inputChart, registryURL, pushChartURL string, opts ...Option) (
 		}
 		if askYesNoQuestion(l.PrefixText("Do you want to push the wrapped images to the OCI registry?"), cfg) {
 			if err := l.Section("Pushing Images", func(subLog dtlog.SectionLogger) error {
-				return pushChartImagesAndVerify(ctx, wrap, NewConfig(append(opts, WithLogger(subLog))...))
+				return pushChartImagesAndVerify(ctx, wrap, registryURL, NewConfig(append(opts, WithLogger(subLog))...))
 			}); err != nil {
 				return "", l.Failf("Failed to push images: %w", err)
 			}
@@ -430,13 +444,25 @@ func unwrapContainer(inputContainer, registryURL string, opts ...Option) (string
 	return "", nil
 }
 
-func pushChartImagesAndVerify(ctx context.Context, wrap wrapping.Wrap, cfg *Config) error {
+func pushChartImagesAndVerify(ctx context.Context, wrap wrapping.Wrap, registryURL string, cfg *Config) error {
 	lockFile := wrap.LockFilePath()
 
 	l := cfg.GetLogger()
 	if !utils.FileExists(lockFile) {
 		return fmt.Errorf("lock file %q does not exist", lockFile)
 	}
+
+	if cfg.PreserveDigest {
+		// --preserve-digest forces SkipImageRelocation, which also skips
+		// relocating Images.lock itself (both live behind the same gate in
+		// relocator.relocateChart). Images still need to land at
+		// registryURL, so relocate the lock file directly here, mirroring
+		// what unwrapContainer already does unconditionally.
+		if err := relocator.RelocateLockFile(lockFile, strings.TrimPrefix(registryURL, "oci://"), cfg.PreserveRepository); err != nil {
+			return fmt.Errorf("failed to relocate Images.lock file: %w", err)
+		}
+	}
+
 	if err := push.ChartImages(
 		wrap,
 		wrap.ImagesDir(),
@@ -446,10 +472,22 @@ func pushChartImagesAndVerify(ctx context.Context, wrap wrapping.Wrap, cfg *Conf
 		chartutils.WithProgressBar(l.ProgressBar()),
 		chartutils.WithInsecureMode(cfg.Insecure),
 		chartutils.WithAuth(cfg.ContainerRegistryAuth.Username, cfg.ContainerRegistryAuth.Password),
+		chartutils.WithPreserveDigest(cfg.PreserveDigest),
 	); err != nil {
 		return err
 	}
 	l.Infof("All images pushed successfully")
+
+	if cfg.PreserveDigest {
+		// The chart's own declared image references were deliberately left
+		// unrelocated to preserve its byte-for-byte digest, so they no
+		// longer match the Images.lock just relocated above. Digest
+		// correctness against the source was already checked at pull time
+		// (pullImageVerbatim -> VerifyLockedDigests), so the usual
+		// values.yaml-vs-Images.lock cross-check doesn't apply here.
+		return nil
+	}
+
 	if err := l.ExecuteStep("Verifying Images.lock", func() error {
 
 		return verify.Lock(wrap.ChartDir(), lockFile, verify.Config{
@@ -480,7 +518,8 @@ func pushImages(ctx context.Context, wrap wrapping.WrapContainer, cfg *Config) e
 		chartutils.WithArtifactsDir(wrap.ImageArtifactsDir()),
 		chartutils.WithProgressBar(l.ProgressBar()),
 		chartutils.WithInsecureMode(cfg.Insecure),
-		chartutils.WithAuth(cfg.ContainerRegistryAuth.Username, cfg.ContainerRegistryAuth.Password))
+		chartutils.WithAuth(cfg.ContainerRegistryAuth.Username, cfg.ContainerRegistryAuth.Password),
+		chartutils.WithPreserveDigest(cfg.PreserveDigest))
 }
 
 func getImageList(wrap wrapping.Lockable, l dtlog.SectionLogger) imagelock.ImageList {
@@ -516,6 +555,10 @@ func normalizeOCIURL(url string) string {
 }
 
 func pushChart(ctx context.Context, wrap wrapping.Wrap, pushChartURL string, cfg *Config) error {
+	if cfg.PreserveDigest {
+		return pushPreservedChart(ctx, wrap, pushChartURL, cfg)
+	}
+
 	var tmpDir, dir string
 	var err error
 	tmpDir, err = cfg.GetTemporaryDirectory()
@@ -559,6 +602,58 @@ func pushChart(ctx context.Context, wrap wrapping.Wrap, pushChartURL string, cfg
 	return nil
 }
 
+// pushPreservedChart pushes the chart artifact captured by
+// `dt wrap --preserve-digest` (see capturePreservedChart in cmd/dt/wrap)
+// exactly as stored, bypassing Helm's push action entirely when a raw OCI
+// manifest was captured. This matters because Helm's own registry.Client.Push
+// always stamps a fresh creation-time annotation into a freshly-built
+// manifest on every push, so pushing through it can never reproduce the
+// source's original manifest digest, even given byte-identical tgz content.
+func pushPreservedChart(ctx context.Context, wrap wrapping.Wrap, pushChartURL string, cfg *Config) error {
+	chart := wrap.Chart()
+	fullChartURL := fmt.Sprintf("%s/%s", pushChartURL, chart.Name())
+	dstRef := fmt.Sprintf("%s:%s", strings.TrimPrefix(fullChartURL, "oci://"), chart.Version())
+
+	chartOCIDir := filepath.Join(wrap.RootDir(), "chart.oci")
+	chartTgzPath := filepath.Join(wrap.RootDir(), "chart.tgz")
+
+	switch {
+	case utils.FileExists(chartOCIDir):
+		// Source was oci://: push the exact original manifest+config+layer
+		// bytes, reproducing the source's manifest digest.
+		if err := artifacts.PushVerbatim(ctx, chartOCIDir, dstRef,
+			artifacts.WithAuth(cfg.Auth.Username, cfg.Auth.Password),
+			artifacts.WithInsecureMode(cfg.Insecure)); err != nil {
+			return fmt.Errorf("failed to push preserved chart artifact: %w", err)
+		}
+	case utils.FileExists(chartTgzPath):
+		// Source was a local .tgz: there is no pre-existing OCI manifest to
+		// preserve, but the tgz blob itself is the pristine original bytes.
+		tmpDir, err := cfg.GetTemporaryDirectory()
+		if err != nil {
+			return fmt.Errorf("failed to get temp dir: %w", err)
+		}
+		if err := artifacts.PushChart(chartTgzPath, pushChartURL,
+			artifacts.WithInsecure(cfg.Insecure),
+			artifacts.WithPlainHTTP(cfg.UsePlainHTTP),
+			artifacts.WithRegistryAuth(cfg.Auth.Username, cfg.Auth.Password),
+			artifacts.WithTempDir(tmpDir),
+		); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf(
+			"bundle %q does not contain a preserved chart artifact; re-run \"dt wrap --preserve-digest\" to produce a compatible bundle",
+			wrap.RootDir())
+	}
+
+	metadataArtifactDir := filepath.Join(chart.RootDir(), artifacts.HelmChartArtifactMetadataDir)
+	if utils.FileExists(metadataArtifactDir) {
+		return artifacts.PushChartMetadata(ctx, fmt.Sprintf("%s:%s", fullChartURL, chart.Version()), metadataArtifactDir, artifacts.WithAuth(cfg.Auth.Username, cfg.Auth.Password))
+	}
+	return nil
+}
+
 // NewCmd returns a new unwrap command
 func NewCmd(cfg *config.Config) *cobra.Command {
 	var (
@@ -567,6 +662,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 		version             string
 		skipImageRelocation bool
 		skipPullImages      bool
+		preserveDigest      bool
 	)
 	valuesFiles := []string{"values.yaml"}
 	cmd := &cobra.Command{
@@ -603,6 +699,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 				WithValuesFiles(valuesFiles...),
 				WithSkipImageRelocation(skipImageRelocation),
 				WithSkipPullImages(skipPullImages),
+				WithPreserveDigest(preserveDigest),
 			)
 			if err != nil {
 				return err
@@ -623,6 +720,9 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVar(&valuesFiles, "values", valuesFiles, "values files to relocate images (can specify multiple)")
 	cmd.PersistentFlags().BoolVar(&skipImageRelocation, "skip-image-relocation", skipImageRelocation, "Skip relocating image references in the different files")
 	cmd.PersistentFlags().BoolVar(&skipPullImages, "skip-pull-images", skipPullImages, "Skip pulling images")
+	cmd.PersistentFlags().BoolVar(&preserveDigest, "preserve-digest", preserveDigest,
+		"push the chart and its images byte-for-byte so their digests are unchanged. "+
+			"Implies --skip-image-relocation, and requires a bundle produced by \"dt wrap --preserve-digest\"")
 
 	return cmd
 }
@@ -630,6 +730,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 // NewContainerCmd returns a new unwrap command for container images
 func NewContainerCmd(cfg *config.Config) *cobra.Command {
 	var sayYes bool
+	var preserveDigest bool
 	cmd := &cobra.Command{
 		Use:   "unwrap FILE OCI_REF",
 		Short: "Unwraps a wrapped container image",
@@ -659,6 +760,7 @@ func NewContainerCmd(cfg *config.Config) *cobra.Command {
 				WithTempDirectory(tempDir),
 				WithUsePlainHTTP(cfg.UsePlainHTTP),
 				WithInteractive(true),
+				WithPreserveDigest(preserveDigest),
 			)
 			if err != nil {
 				return err
@@ -670,6 +772,8 @@ func NewContainerCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVar(&sayYes, "yes", sayYes, "respond 'yes' to any yes/no question")
+	cmd.PersistentFlags().BoolVar(&preserveDigest, "preserve-digest", preserveDigest,
+		"push the image byte-for-byte instead of relocating/re-packaging it, so its digest (and any signature made against it) remains unchanged")
 
 	return cmd
 }

--- a/cmd/dt/wrap/wrap.go
+++ b/cmd/dt/wrap/wrap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vmware-labs/distribution-tooling-for-helm/cmd/dt/carvelize"
@@ -49,6 +50,8 @@ type Config struct {
 	Auth                  Auth
 	ContainerRegistryAuth Auth
 	OutputFile            string
+	PreserveDigest        bool
+	PreservedSourceRef    string
 }
 
 // WithKeepArtifacts configures the KeepArtifacts of the WrapConfig
@@ -135,6 +138,25 @@ func WithFetchArtifacts(fetchArtifacts bool) func(c *Config) {
 func WithSkipPullImages(skipPullImages bool) func(c *Config) {
 	return func(c *Config) {
 		c.SkipPullImages = skipPullImages
+	}
+}
+
+// WithPreserveDigest configures the PreserveDigest of the WrapConfig
+func WithPreserveDigest(preserveDigest bool) func(c *Config) {
+	return func(c *Config) {
+		c.PreserveDigest = preserveDigest
+	}
+}
+
+// WithPreservedSourceRef configures the PreservedSourceRef of the WrapConfig.
+// When set, --preserve-digest captures the pristine chart artifact from this
+// oci:// reference instead of inspecting inputPath, letting a caller that has
+// already resolved inputPath to a local .tgz for other purposes (e.g.
+// dependency inspection) still get true manifest byte-preservation, without a
+// second, redundant full-chart download through ResolveInputChartPath.
+func WithPreservedSourceRef(ref string) func(c *Config) {
+	return func(c *Config) {
+		c.PreservedSourceRef = ref
 	}
 }
 
@@ -377,6 +399,7 @@ func pullImages(wrap wrapping.Wrap, cfg *Config) error {
 				chartutils.WithArtifactsDir(wrap.ImageArtifactsDir()),
 				chartutils.WithProgressBar(childLog.ProgressBar()),
 				chartutils.WithInsecureMode(cfg.Insecure),
+				chartutils.WithPreserveDigest(cfg.PreserveDigest),
 			); err != nil {
 				return childLog.Failf("%v", err)
 			}
@@ -385,6 +408,64 @@ func pullImages(wrap wrapping.Wrap, cfg *Config) error {
 		})
 	}
 	return nil
+}
+
+// validatePreserveDigest rejects flag/input combinations that are
+// contradictory when PreserveDigest is requested: digest preservation
+// requires an already-packaged chart artifact (there is no canonical
+// byte-serialization of a source directory), the full unfiltered manifest
+// list (platform filtering defeats the point), and unmodified chart content
+// (Carvelize writes new files into the chart).
+func validatePreserveDigest(inputPath string, cfg *Config) error {
+	if !cfg.PreserveDigest {
+		return nil
+	}
+	if len(cfg.Platforms) > 0 {
+		return fmt.Errorf("cannot combine --preserve-digest with --platforms: digest preservation requires the full, unfiltered manifest list")
+	}
+	if cfg.Carvelize {
+		return fmt.Errorf("cannot combine --preserve-digest with --add-carvel-bundle: it would modify chart content, defeating byte preservation")
+	}
+	if cfg.PreservedSourceRef != "" || chartutils.IsRemoteChart(inputPath) {
+		return nil
+	}
+	if isTar, _ := utils.IsTarFile(inputPath); isTar {
+		return nil
+	}
+	return fmt.Errorf("cannot preserve digest: input %q must be an already-packaged chart (a .tgz file or an oci:// reference), not a directory", inputPath)
+}
+
+// capturePreservedChart saves the original, byte-for-byte chart artifact into
+// the wrap bundle for later use by `dt unwrap --preserve-digest`, so the
+// destination chart never goes through an untar/copy/re-tar round trip (or,
+// for oci:// sources, a re-push through Helm's registry client, which always
+// rebuilds the manifest with a fresh creation-time annotation).
+func capturePreservedChart(inputPath string, version string, wrap wrapping.Wrap, cfg *Config) error {
+	sourceRef := cfg.PreservedSourceRef
+	if sourceRef == "" && chartutils.IsRemoteChart(inputPath) {
+		sourceRef = inputPath
+	}
+
+	if sourceRef != "" {
+		// sourceRef is already resolved to a concrete chart version by the
+		// time this runs (chart.Version() reflects what ResolveInputChartPath
+		// actually fetched, or what the caller supplied via
+		// PreservedSourceRef), so re-fetching that exact tag via a raw OCI
+		// artifact copy is consistent with what was already downloaded.
+		ref := fmt.Sprintf("%s:%s", strings.TrimPrefix(sourceRef, "oci://"), version)
+		chartOCIDir := filepath.Join(wrap.RootDir(), "chart.oci")
+		if _, err := artifacts.PullVerbatim(cfg.Context, ref, chartOCIDir,
+			artifacts.WithAuth(cfg.Auth.Username, cfg.Auth.Password),
+			artifacts.WithInsecureMode(cfg.Insecure)); err != nil {
+			return fmt.Errorf("failed to fetch original chart artifact %q: %w", ref, err)
+		}
+		return nil
+	}
+
+	// Local .tgz input (validated by validatePreserveDigest): carry the exact
+	// original bytes into the bundle untouched.
+	chartTgzPath := filepath.Join(wrap.RootDir(), "chart.tgz")
+	return utils.CopyFile(inputPath, chartTgzPath)
 }
 
 func wrapChart(inputPath string, opts ...Option) (string, error) {
@@ -396,6 +477,10 @@ func wrapChart(inputPath string, opts ...Option) (string, error) {
 	l := parentLog.StartSection(fmt.Sprintf("Wrapping Helm chart %q", inputPath))
 
 	subCfg := NewConfig(append(opts, WithLogger(l))...)
+
+	if err := validatePreserveDigest(inputPath, cfg); err != nil {
+		return "", l.Failf("%w", err)
+	}
 
 	chartPath, err := ResolveInputChartPath(inputPath, subCfg)
 	if err != nil {
@@ -415,6 +500,12 @@ func wrapChart(inputPath string, opts ...Option) (string, error) {
 	}
 
 	chart := wrap.Chart()
+
+	if cfg.PreserveDigest {
+		if err = capturePreservedChart(inputPath, chart.Version(), wrap, subCfg); err != nil {
+			return "", l.Failf("failed to preserve chart digest: %w", err)
+		}
+	}
 
 	if cfg.ShouldFetchChartArtifacts(inputPath) {
 		chartURL := fmt.Sprintf("%s:%s", inputPath, chart.Version())
@@ -478,6 +569,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 	var fetchArtifacts bool
 	var carvelize bool
 	var skipPullImages bool
+	var preserveDigest bool
 	var examples = `  # Wrap a Helm chart from a local folder
   $ dt wrap examples/mariadb
 
@@ -515,6 +607,7 @@ This command will pull all the container images and wrap it into a single tarbal
 				WithOutputFile(outputFile),
 				WithTempDirectory(tmpDir),
 				WithSkipPullImages(skipPullImages),
+				WithPreserveDigest(preserveDigest),
 			)
 			if err != nil {
 				if _, ok := err.(*dtlog.LoggedError); ok {
@@ -537,6 +630,10 @@ This command will pull all the container images and wrap it into a single tarbal
 	cmd.PersistentFlags().BoolVar(&carvelize, "add-carvel-bundle", carvelize, "whether the wrap should include a Carvel bundle or not")
 	cmd.PersistentFlags().BoolVar(&fetchArtifacts, "fetch-artifacts", fetchArtifacts, "fetch remote metadata and signature artifacts")
 	cmd.PersistentFlags().BoolVar(&skipPullImages, "skip-pull-images", skipPullImages, "skip pulling images when wrapping a Helm Chart")
+	cmd.PersistentFlags().BoolVar(&preserveDigest, "preserve-digest", preserveDigest,
+		"transfer the chart and its images byte-for-byte so their digests are unchanged. "+
+			"Requires an already-packaged chart (a .tgz file or an oci:// reference); "+
+			"incompatible with --platforms and --add-carvel-bundle")
 
 	return cmd
 }
@@ -552,6 +649,10 @@ func wrapContainer(imageRef string, opts ...Option) (string, error) {
 	ctx := cfg.Context
 	l := cfg.GetLogger().StartSection(fmt.Sprintf("Wrapping container image %q", imageRef))
 	cfg.logger = l
+
+	if cfg.PreserveDigest && len(cfg.Platforms) > 0 {
+		return "", l.Failf("cannot combine --preserve-digest with --platforms: digest preservation requires the full, unfiltered manifest list")
+	}
 
 	tmpDir, err := cfg.GetTemporaryDirectory()
 	if err != nil {
@@ -606,6 +707,7 @@ func wrapContainer(imageRef string, opts ...Option) (string, error) {
 				chartutils.WithArtifactsDir(wc.ImageArtifactsDir()),
 				chartutils.WithProgressBar(childLog.ProgressBar()),
 				chartutils.WithInsecureMode(cfg.Insecure),
+				chartutils.WithPreserveDigest(cfg.PreserveDigest),
 			)
 		})
 		if err != nil {
@@ -646,6 +748,7 @@ func NewContainerCmd(cfg *config.Config) *cobra.Command {
 	var outputFile string
 	var platforms []string
 	var fetchArtifacts bool
+	var preserveDigest bool
 
 	cmd := &cobra.Command{
 		Use:   "wrap OCI_REF",
@@ -687,6 +790,7 @@ with an Images.lock file into a single tarball.`,
 				WithInsecure(cfg.Insecure),
 				WithOutputFile(outputFile),
 				WithTempDirectory(tmpDir),
+				WithPreserveDigest(preserveDigest),
 			)
 			if err != nil {
 				if _, ok := err.(*dtlog.LoggedError); ok {
@@ -705,6 +809,8 @@ with an Images.lock file into a single tarball.`,
 	cmd.PersistentFlags().StringVar(&outputFile, "output-file", outputFile, "output tarball path (defaults to <name>-<tag>.container.wrap.tgz)")
 	cmd.PersistentFlags().StringSliceVar(&platforms, "platforms", platforms, "platforms to include in the Images.lock file (e.g. linux/amd64,linux/arm64)")
 	cmd.PersistentFlags().BoolVar(&fetchArtifacts, "fetch-artifacts", fetchArtifacts, "fetch remote metadata and signature artifacts")
+	cmd.PersistentFlags().BoolVar(&preserveDigest, "preserve-digest", preserveDigest,
+		"transfer the image byte-for-byte instead of relocating/re-packaging it, so its digest (and any signature made against it) remains unchanged. Incompatible with --platforms")
 
 	return cmd
 }

--- a/pkg/artifacts/verbatim.go
+++ b/pkg/artifacts/verbatim.go
@@ -1,0 +1,227 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	digest "github.com/opencontainers/go-digest"
+
+	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/imagelock"
+)
+
+func verbatimCraneOptions(ctx context.Context, cfg *Config) []crane.Option {
+	opts := []crane.Option{crane.WithContext(ctx)}
+	if cfg.InsecureMode {
+		opts = append(opts, crane.Insecure)
+	}
+	if cfg.Auth.Username != "" && cfg.Auth.Password != "" {
+		opts = append(opts, crane.WithAuth(&authn.Basic{
+			Username: cfg.Auth.Username,
+			Password: cfg.Auth.Password,
+		}))
+	}
+	return opts
+}
+
+// PullVerbatim fetches the OCI artifact referenced by ref exactly as served by
+// the registry - a single manifest or a full, unfiltered index, whichever it
+// is - and stores it as a single-entry OCI layout directory at destDir. It
+// never goes through pkg/v1/mutate, so the artifact's manifest/index digest,
+// and every nested per-platform manifest and layer digest, are preserved
+// byte-for-byte. The returned descriptor carries the digest(s) actually found
+// upstream, for callers that want to cross-check them (see
+// VerifyLockedDigests).
+func PullVerbatim(ctx context.Context, ref string, destDir string, opts ...Option) (*remote.Descriptor, error) {
+	cfg := NewConfig(opts...)
+	craneOpts := verbatimCraneOptions(ctx, cfg)
+
+	desc, err := imagelock.GetImageRemoteDescriptor(ref, craneOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %q: %w", ref, err)
+	}
+
+	if err = os.MkdirAll(destDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create %q: %w", destDir, err)
+	}
+
+	p, err := layout.Write(destDir, empty.Index)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize OCI layout at %q: %w", destDir, err)
+	}
+
+	switch {
+	case desc.MediaType.IsIndex():
+		idx, err := desc.ImageIndex()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read image index for %q: %w", ref, err)
+		}
+		if err := p.AppendIndex(idx); err != nil {
+			return nil, fmt.Errorf("failed to store image index for %q: %w", ref, err)
+		}
+	case desc.MediaType.IsImage():
+		img, err := desc.Image()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read image for %q: %w", ref, err)
+		}
+		if err := p.AppendImage(img); err != nil {
+			return nil, fmt.Errorf("failed to store image for %q: %w", ref, err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported media type %q for %q", desc.MediaType, ref)
+	}
+	return desc, nil
+}
+
+// loadVerbatimEntry loads the single top-level entry (a v1.Image or a
+// v1.ImageIndex) previously written by PullVerbatim from the OCI layout
+// directory at dir, without re-serializing it - RawManifest() on the returned
+// object returns the exact bytes originally fetched from the source registry.
+func loadVerbatimEntry(dir string) (any, error) {
+	l, err := layout.FromPath(dir)
+	if err != nil {
+		return nil, fmt.Errorf("loading %q as OCI layout: %w", dir, err)
+	}
+	rootIdx, err := l.ImageIndex()
+	if err != nil {
+		return nil, err
+	}
+	im, err := rootIdx.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	if len(im.Manifests) != 1 {
+		return nil, fmt.Errorf("layout %q contains %d entries, expected exactly 1", dir, len(im.Manifests))
+	}
+	desc := im.Manifests[0]
+	switch {
+	case desc.MediaType.IsIndex():
+		return rootIdx.ImageIndex(desc.Digest)
+	case desc.MediaType.IsImage():
+		return rootIdx.Image(desc.Digest)
+	default:
+		return nil, fmt.Errorf("layout %q contains unsupported media type %q", dir, desc.MediaType)
+	}
+}
+
+// PushVerbatim reads the single-entry OCI layout directory previously written
+// by PullVerbatim at srcDir and pushes it to dstRef exactly as stored - again,
+// never through pkg/v1/mutate - preserving its digest. After pushing, it
+// re-fetches dstRef's digest from the registry and fails loudly on any
+// mismatch against the digest of what was pushed, guarding against
+// non-conformant registries that mutate manifests on write.
+func PushVerbatim(ctx context.Context, srcDir string, dstRef string, opts ...Option) error {
+	cfg := NewConfig(opts...)
+	craneOpts := verbatimCraneOptions(ctx, cfg)
+	o := crane.GetOptions(craneOpts...)
+
+	entry, err := loadVerbatimEntry(srcDir)
+	if err != nil {
+		return fmt.Errorf("failed to load OCI layout at %q: %w", srcDir, err)
+	}
+
+	ref, err := name.ParseReference(dstRef, o.Name...)
+	if err != nil {
+		return fmt.Errorf("failed to parse reference %q: %w", dstRef, err)
+	}
+
+	var wantDigest v1.Hash
+	switch t := entry.(type) {
+	case v1.ImageIndex:
+		if wantDigest, err = t.Digest(); err != nil {
+			return fmt.Errorf("failed to compute digest for %q: %w", dstRef, err)
+		}
+		if err = remote.WriteIndex(ref, t, o.Remote...); err != nil {
+			return fmt.Errorf("failed to push %q: %w", dstRef, err)
+		}
+	case v1.Image:
+		if wantDigest, err = t.Digest(); err != nil {
+			return fmt.Errorf("failed to compute digest for %q: %w", dstRef, err)
+		}
+		if err = remote.Write(ref, t, o.Remote...); err != nil {
+			return fmt.Errorf("failed to push %q: %w", dstRef, err)
+		}
+	default:
+		return fmt.Errorf("unsupported artifact type %T for %q", t, dstRef)
+	}
+
+	got, err := remote.Head(ref, o.Remote...)
+	if err != nil {
+		return fmt.Errorf("failed to verify pushed digest for %q: %w", dstRef, err)
+	}
+	if got.Digest != wantDigest {
+		return fmt.Errorf("digest mismatch after pushing %q: pushed %s, registry reports %s", dstRef, wantDigest, got.Digest)
+	}
+	return nil
+}
+
+// VerifyLockedDigests cross-checks the per-platform digests recorded in
+// image.Digests (as generated when Images.lock was written) against the
+// digests actually present in desc, a descriptor freshly fetched from the
+// source registry (e.g. via PullVerbatim). It returns an error on any
+// mismatch or missing platform.
+//
+// This is the only safe use of Images.lock's per-platform digest list in a
+// digest-preserving transfer: Images.lock is a lossy projection of the source
+// index (imagelock.readDigestsInfoFromIndex deliberately drops
+// attestation-manifest entries), so it can never be used to *reconstruct* an
+// index byte-for-byte - only to sanity-check, after an independent verbatim
+// fetch, that the tag referenced by image.Image still points at the content
+// that was locked. This guards against a TOCTOU where the upstream tag moved
+// between "Images.lock generation" and "mirror" time.
+func VerifyLockedDigests(image *imagelock.ChartImage, desc *remote.Descriptor) error {
+	switch {
+	case desc.MediaType.IsIndex():
+		idx, err := desc.ImageIndex()
+		if err != nil {
+			return fmt.Errorf("failed to read image index for %q: %w", image.Image, err)
+		}
+		im, err := idx.IndexManifest()
+		if err != nil {
+			return fmt.Errorf("failed to read index manifest for %q: %w", image.Image, err)
+		}
+		found := make(map[string]digest.Digest)
+		for _, m := range im.Manifests {
+			if !m.MediaType.IsImage() || m.Platform == nil {
+				continue
+			}
+			arch := fmt.Sprintf("%s/%s", m.Platform.OS, m.Platform.Architecture)
+			found[arch] = digest.Digest(m.Digest.String())
+		}
+		var allErrors error
+		for _, want := range image.Digests {
+			got, ok := found[want.Arch]
+			if !ok {
+				allErrors = errors.Join(allErrors, fmt.Errorf(
+					"locked digest for %q arch %q not found in remote index (upstream tag may have moved)",
+					image.Image, want.Arch))
+				continue
+			}
+			if got != want.Digest {
+				allErrors = errors.Join(allErrors, fmt.Errorf(
+					"digest mismatch for %q arch %q: locked %s, remote %s",
+					image.Image, want.Arch, want.Digest, got))
+			}
+		}
+		return allErrors
+	case desc.MediaType.IsImage():
+		if len(image.Digests) != 1 {
+			return fmt.Errorf("expected exactly one locked digest for single-manifest image %q, got %d", image.Image, len(image.Digests))
+		}
+		got := digest.Digest(desc.Digest.String())
+		if got != image.Digests[0].Digest {
+			return fmt.Errorf("digest mismatch for %q: locked %s, remote %s", image.Image, image.Digests[0].Digest, got)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported media type %q for %q", desc.MediaType, image.Image)
+	}
+}

--- a/pkg/artifacts/verbatim_test.go
+++ b/pkg/artifacts/verbatim_test.go
@@ -1,0 +1,87 @@
+package artifacts
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/imagelock"
+)
+
+func newTestRegistry(t *testing.T) string {
+	t.Helper()
+	silentLog := log.New(io.Discard, "", 0)
+	s := httptest.NewServer(registry.New(registry.Logger(silentLog)))
+	t.Cleanup(s.Close)
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+	return u.Host
+}
+
+func TestPullPushVerbatimSingleImage(t *testing.T) {
+	serverURL := newTestRegistry(t)
+	ctx := context.Background()
+
+	img, err := crane.Image(map[string][]byte{"file.txt": []byte("hello")})
+	require.NoError(t, err)
+
+	srcRef := fmt.Sprintf("%s/single:latest", serverURL)
+	require.NoError(t, crane.Push(img, srcRef))
+
+	srcDigest, err := crane.Digest(srcRef)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	destDir := filepath.Join(dir, "layout")
+
+	desc, err := PullVerbatim(ctx, srcRef, destDir)
+	require.NoError(t, err)
+	require.True(t, desc.MediaType.IsImage())
+	require.Equal(t, srcDigest, desc.Digest.String())
+
+	dstRef := fmt.Sprintf("%s/single-copy:latest", serverURL)
+	require.NoError(t, PushVerbatim(ctx, destDir, dstRef))
+
+	dstDigest, err := crane.Digest(dstRef)
+	require.NoError(t, err)
+	require.Equal(t, srcDigest, dstDigest, "digest must be preserved across PullVerbatim+PushVerbatim")
+}
+
+func TestVerifyLockedDigestsSingleManifest(t *testing.T) {
+	serverURL := newTestRegistry(t)
+
+	img, err := crane.Image(map[string][]byte{"file.txt": []byte("hello")})
+	require.NoError(t, err)
+
+	ref := fmt.Sprintf("%s/single:latest", serverURL)
+	require.NoError(t, crane.Push(img, ref))
+
+	desc, err := imagelock.GetImageRemoteDescriptor(ref)
+	require.NoError(t, err)
+
+	image := &imagelock.ChartImage{
+		Image: ref,
+		Digests: []imagelock.DigestInfo{
+			{Arch: "linux/amd64", Digest: digest.Digest(desc.Digest.String())},
+		},
+	}
+	require.NoError(t, VerifyLockedDigests(image, desc))
+
+	tampered := &imagelock.ChartImage{
+		Image: ref,
+		Digests: []imagelock.DigestInfo{
+			{Arch: "linux/amd64", Digest: digest.Digest("sha256:0000000000000000000000000000000000000000000000000000000000000000")},
+		},
+	}
+	require.Error(t, VerifyLockedDigests(tampered, desc), "a locked digest that does not match the remote content must be rejected")
+}

--- a/pkg/chartutils/images.go
+++ b/pkg/chartutils/images.go
@@ -38,6 +38,71 @@ func getArtifactsDir(defaultValue string, cfg *Configuration) string {
 	return defaultValue
 }
 
+// pullImageVerbatim pulls imgDesc's full, unfiltered manifest/index exactly as
+// served upstream, then cross-checks it against the digests recorded in
+// Images.lock. Used when Configuration.PreserveDigest is set.
+func pullImageVerbatim(ctx context.Context, imgDesc *imagelock.ChartImage, imagesDir string, cfg *Configuration, p dtlog.ProgressBar) error {
+	select {
+	// Early abort if the context is done
+	case <-ctx.Done():
+		return fmt.Errorf("cancelled execution")
+	default:
+	}
+	p.Add(len(imgDesc.Digests))
+	p.UpdateTitle(fmt.Sprintf("Saving image %s/%s %s (verbatim)", imgDesc.Chart, imgDesc.Name, imgDesc.Image))
+	err := utils.ExecuteWithRetry(cfg.MaxRetries, func(try int, prevErr error) error {
+		if try > 0 {
+			if ctx.Err() != nil {
+				return prevErr
+			}
+			cfg.Log.Debugf("Failed to pull image: %v", prevErr)
+			p.Warnf("Failed to pull image: retrying %d/%d", try, cfg.MaxRetries)
+		}
+		desc, pullErr := artifacts.PullVerbatim(ctx, imgDesc.Image, verbatimImageDir(imagesDir, imgDesc),
+			artifacts.WithAuth(cfg.Auth.Username, cfg.Auth.Password),
+			artifacts.WithInsecureMode(cfg.InsecureMode))
+		if pullErr != nil {
+			return pullErr
+		}
+		return artifacts.VerifyLockedDigests(imgDesc, desc)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", imgDesc.Name, err)
+	}
+	return nil
+}
+
+// pullImagePerPlatform pulls each of imgDesc's recorded per-platform digests
+// individually. Used when Configuration.PreserveDigest is not set.
+func pullImagePerPlatform(ctx context.Context, imgDesc *imagelock.ChartImage, imagesDir string, cfg *Configuration, o crane.Options, p dtlog.ProgressBar) error {
+	for _, dgst := range imgDesc.Digests {
+		select {
+		// Early abort if the context is done
+		case <-ctx.Done():
+			return fmt.Errorf("cancelled execution")
+		default:
+			p.Add(1)
+			p.UpdateTitle(fmt.Sprintf("Saving image %s/%s %s (%s)", imgDesc.Chart, imgDesc.Name, imgDesc.Image, dgst.Arch))
+			err := utils.ExecuteWithRetry(cfg.MaxRetries, func(try int, prevErr error) error {
+				if try > 0 {
+					// The context is done, so we are not retrying, just return the error
+					if ctx.Err() != nil {
+						return prevErr
+					}
+					cfg.Log.Debugf("Failed to pull image: %v", prevErr)
+					p.Warnf("Failed to pull image: retrying %d/%d", try, cfg.MaxRetries)
+				}
+				_, pullErr := pullImage(imgDesc.Image, dgst, imagesDir, o)
+				return pullErr
+			})
+			if err != nil {
+				return fmt.Errorf("failed to pull image %q: %w", imgDesc.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
 // PullImages downloads the list of images specified in the provided ImagesLock
 func PullImages(lock *imagelock.ImagesLock, imagesDir string, opts ...Option) error {
 
@@ -67,36 +132,16 @@ func PullImages(lock *imagelock.ImagesLock, imagesDir string, opts ...Option) er
 
 	p, _ := cfg.ProgressBar.WithTotal(getNumberOfArtifacts(lock.Images)).UpdateTitle("Pulling Images").Start()
 	defer p.Stop()
-	maxRetries := cfg.MaxRetries
 
 	for _, imgDesc := range lock.Images {
-		for _, dgst := range imgDesc.Digests {
-			select {
-			// Early abort if the context is done
-			case <-ctx.Done():
-				return fmt.Errorf("cancelled execution")
-			default:
-				p.Add(1)
-				p.UpdateTitle(fmt.Sprintf("Saving image %s/%s %s (%s)", imgDesc.Chart, imgDesc.Name, imgDesc.Image, dgst.Arch))
-				err := utils.ExecuteWithRetry(maxRetries, func(try int, prevErr error) error {
-					if try > 0 {
-						// The context is done, so we are not retrying, just return the error
-						if ctx.Err() != nil {
-							return prevErr
-						}
-						l.Debugf("Failed to pull image: %v", prevErr)
-						p.Warnf("Failed to pull image: retrying %d/%d", try, maxRetries)
-					}
-					if _, err := pullImage(imgDesc.Image, dgst, imagesDir, o); err != nil {
-						return err
-					}
-					return nil
-				})
-
-				if err != nil {
-					return fmt.Errorf("failed to pull image %q: %w", imgDesc.Name, err)
-				}
-			}
+		var err error
+		if cfg.PreserveDigest {
+			err = pullImageVerbatim(ctx, imgDesc, imagesDir, cfg, p)
+		} else {
+			err = pullImagePerPlatform(ctx, imgDesc, imagesDir, cfg, o, p)
+		}
+		if err != nil {
+			return err
 		}
 		if cfg.FetchArtifacts {
 			p.UpdateTitle(fmt.Sprintf("Saving image %s/%s signature", imgDesc.Chart, imgDesc.Name))
@@ -165,7 +210,13 @@ func PushImages(lock *imagelock.ImagesLock, imagesDir string, opts ...Option) er
 					l.Debugf("Failed to push image: %v", prevErr)
 					p.Warnf("Failed to push image: retrying %d/%d", try, maxRetries)
 				}
-				if err := pushImage(imgData, imagesDir, l, o); err != nil {
+				if cfg.PreserveDigest {
+					if err := artifacts.PushVerbatim(ctx, verbatimImageDir(imagesDir, imgData), imgData.Image,
+						artifacts.WithAuth(cfg.Auth.Username, cfg.Auth.Password),
+						artifacts.WithInsecureMode(cfg.InsecureMode)); err != nil {
+						return err
+					}
+				} else if err := pushImage(imgData, imagesDir, l, o); err != nil {
 					return err
 				}
 				if err := artifacts.PushImageSignatures(context.Background(),
@@ -289,6 +340,15 @@ func pushImage(imgData *imagelock.ChartImage, imagesDir string, log dtlog.Logger
 
 func getImageLayoutDir(imagesDir string, dgst imagelock.DigestInfo) string {
 	return filepath.Join(imagesDir, fmt.Sprintf("%s.layout", dgst.Digest.Encoded()))
+}
+
+// verbatimImageDir returns the local OCI layout directory used to stage a
+// digest-preserving (PreserveDigest) pull/push of the given image. Unlike
+// getImageLayoutDir, this is keyed by the image's chart/name rather than a
+// per-platform digest, since a digest-preserving transfer captures the whole
+// manifest/index in one shot, before any digest is known locally.
+func verbatimImageDir(imagesDir string, imgDesc *imagelock.ChartImage) string {
+	return filepath.Join(imagesDir, "verbatim", imgDesc.Chart, imgDesc.Name)
 }
 
 func pullImage(image string, digest imagelock.DigestInfo, imagesDir string, o crane.Options) (string, error) {

--- a/pkg/chartutils/images_test.go
+++ b/pkg/chartutils/images_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -170,4 +171,62 @@ func (suite *ChartUtilsTestSuite) TestPushImages() {
 			}
 		})
 	})
+}
+
+// TestPullPushImagesPreserveDigest proves that with PreserveDigest set,
+// PullImages+PushImages round-trip a multi-arch image such that the
+// destination's manifest-list digest is identical to the source's - the
+// property the default pullImage/buildImageIndex path cannot guarantee (it
+// always reconstructs the index via mutate, forcing DockerManifestList media
+// type and re-deriving each entry rather than preserving the original bytes).
+func (suite *ChartUtilsTestSuite) TestPullPushImagesPreserveDigest() {
+	sb := suite.sb
+	require := suite.Require()
+
+	silentLog := log.New(io.Discard, "", 0)
+	s := httptest.NewServer(registry.New(registry.Logger(silentLog)))
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	require.NoError(err)
+	serverURL := u.Host
+
+	imageName := "test:mytag"
+
+	images, err := tu.AddSampleImagesToRegistry(imageName, serverURL)
+	require.NoError(err)
+
+	scenarioDir := "../../testdata/scenarios/complete-chart"
+	chartName := "test"
+	chartDir := sb.TempFile()
+	require.NoError(tu.RenderScenario(scenarioDir, chartDir,
+		map[string]any{"ServerURL": serverURL, "Images": images, "Name": chartName, "RepositoryURL": serverURL},
+	))
+
+	lock, err := imagelock.FromYAMLFile(filepath.Join(chartDir, "Images.lock"))
+	require.NoError(err)
+	require.NotEmpty(lock.Images)
+
+	srcRef := fmt.Sprintf("%s/%s", serverURL, imageName)
+	srcDigest, err := crane.Digest(srcRef)
+	require.NoError(err)
+
+	imagesDir := filepath.Join(chartDir, "images")
+	require.NoError(PullImages(lock, imagesDir, WithPreserveDigest(true)))
+
+	// Point the (in-memory) lock at a different destination namespace,
+	// mirroring how relocation computes push targets without touching the
+	// persisted Images.lock on disk.
+	dstNamespace := serverURL + "/dst-ns"
+	for _, img := range lock.Images {
+		img.Image = strings.Replace(img.Image, serverURL, dstNamespace, 1)
+	}
+
+	require.NoError(PushImages(lock, imagesDir, WithPreserveDigest(true)))
+
+	dstRef := fmt.Sprintf("%s/%s", dstNamespace, imageName)
+	dstDigest, err := crane.Digest(dstRef)
+	require.NoError(err)
+
+	require.Equal(srcDigest, dstDigest, "manifest-list digest must be preserved end to end")
 }

--- a/pkg/chartutils/options.go
+++ b/pkg/chartutils/options.go
@@ -28,6 +28,7 @@ type Configuration struct {
 	Auth               Auth
 	ValuesFiles        []string
 	PreserveRepository bool
+	PreserveDigest     bool
 }
 
 // WithInsecureMode configures Insecure transport
@@ -131,5 +132,14 @@ func WithValuesFiles(files ...string) func(cfg *Configuration) {
 func WithPreserveRepository(preserve bool) func(cfg *Configuration) {
 	return func(cfg *Configuration) {
 		cfg.PreserveRepository = preserve
+	}
+}
+
+// WithPreserveDigest configures whether images are pulled/pushed byte-for-byte
+// (full, unfiltered manifest/index, no reconstruction) instead of being
+// rebuilt from the per-platform digests recorded in Images.lock
+func WithPreserveDigest(preserve bool) func(cfg *Configuration) {
+	return func(cfg *Configuration) {
+		cfg.PreserveDigest = preserve
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--preserve-digest` to `dt wrap`/`dt unwrap` (chart and container-image
  variants) to transfer a chart artifact and its images byte-for-byte, so
  their digests — and any Cosign signature made against them — survive the
  round trip unchanged.
- New `pkg/artifacts.PullVerbatim`/`PushVerbatim` copy an OCI artifact
  (single manifest or full index) via `remote.Get`/`remote.Write`, never
  through `pkg/v1/mutate`, fixing two independent sources of digest drift:
  the chart's untar→copy→re-tar cycle (and Helm's OCI push client always
  stamping a fresh manifest), and the image path's manifest-list
  reconstruction (which forced Docker-manifest-list media type and dropped
  attestation-manifest entries regardless of `--platforms`).
- `VerifyLockedDigests` cross-checks `Images.lock`'s per-platform digests
  against the verbatim-fetched manifest as a TOCTOU guard.
- Exposed as `wrap.WithPreserveDigest`/`unwrap.WithPreserveDigest` functional
  options, so library consumers (e.g. bitnami/charts-syncer) can use this
  without going through the CLI.
- Fully additive: new fields default to `false`, new code lives in new
  files/functions, existing wrap/unwrap/relocate/push/pull behavior is
  unchanged when the flag is unset.

Motivated by bitnami/charts-syncer#369 — its air-gapped mirroring workflow
needs the destination chart's digest to exactly match the source so a Cosign
signature made against the original chart still verifies at the destination.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — clean
- [x] `go test ./...` — full existing suite passes unchanged
- [x] New unit tests: `pkg/artifacts/verbatim_test.go` (single-manifest
      round trip, `VerifyLockedDigests` mismatch detection)
- [x] New integration test: `pkg/chartutils/images_test.go`
      (`TestPullPushImagesPreserveDigest` — multi-arch manifest-list digest
      preserved end to end across two registry namespaces)
- [x] New end-to-end test: `cmd/dt/unwrap/preserve_digest_test.go`
      (`TestPreserveDigestChartManifest` — chart OCI manifest digest
      identical after wrap+unwrap into a different registry)
- [ ] Manual smoke test against a non-trivial real registry (Harbor/
      Artifactory/Nexus), not just the in-repo test double — registry-side
      conformance for byte-preservation on PUT/GET is an assumption